### PR TITLE
No gen-class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ pom.xml.asc
 .lein-plugins
 .lein-repl-history
 .lein-env
+
+.idea/
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                   :exclusions [javax.servlet/servlet-api]]
                  [ring/ring-servlet "1.2.1"
                   :exclusions [javax.servlet/servlet-api]]
-                 [org.eclipse.jetty/jetty-server "9.1.0.v20131115"]
-                 [org.eclipse.jetty/jetty-jmx "9.1.0.v20131115"]
-                 [org.eclipse.jetty.websocket/websocket-server "9.1.0.v20131115"]
-                 [org.eclipse.jetty.websocket/websocket-servlet "9.1.0.v20131115"]])
+                 [org.eclipse.jetty/jetty-server "9.1.1.v20140108"]
+                 [org.eclipse.jetty/jetty-jmx "9.1.1.v20140108"]
+                 [org.eclipse.jetty.websocket/websocket-server "9.1.1.v20140108"]
+                 [org.eclipse.jetty.websocket/websocket-servlet "9.1.1.v20140108"]])

--- a/test/ring/adapter/jetty9_test.clj
+++ b/test/ring/adapter/jetty9_test.clj
@@ -8,9 +8,10 @@
 (deftest jetty9-test
   (is (run-jetty dummy-app {:port 50524
                             :join? false
-                            :websockets {"/path" {:connect-fn #(prn "connect-fn" % %2)
-                                                  :text-fn    #(prn "text-fn" % %2)
-                                                  :binary-fn  #(prn "binary-fn" % %2 %3 %4)
-                                                  :close-fn   #(prn "close-fn" % %2 %3)
-                                                  :error-fn   #(prn "error-fn" % %2)}}})))
+                            :websockets {"/path" {:create-fn  #(do {:status 200})
+                                                  :connect-fn #(prn "connect-fn" % %2 %3)
+                                                  :text-fn    #(prn "text-fn" % %2 %3 %4)
+                                                  :binary-fn  #(prn "binary-fn" % %2 %3 %4 %5)
+                                                  :close-fn   #(prn "close-fn" % %2 %3 %4)
+                                                  :error-fn   #(prn "error-fn" % %2 %3)}}})))
 


### PR DESCRIPTION
Hi,

This is an example of a working ring-jetty9-adapter without gen-class.
It's not ready for merging, I'm PRing this mostly for feedback.

As you can see, I changed the API from passing a single class, to a map of fns, each handling a websocket event on that context path.

Thanks.
