### PR TITLE
Upgrade jetty versions for security upgrade

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [ring/ring-servlet "1.3.2"
                   :exclusions [javax.servlet/servlet-api]]
-                 [org.eclipse.jetty/jetty-server "9.2.7.v20150116"]
-                 [org.eclipse.jetty.websocket/websocket-server "9.2.7.v20150116"]
-                 [org.eclipse.jetty.websocket/websocket-servlet "9.2.7.v20150116"]]
+                 [org.eclipse.jetty/jetty-server "9.2.9.v20150224"]
+                 [org.eclipse.jetty.websocket/websocket-server "9.2.9.v20150224"]
+                 [org.eclipse.jetty.websocket/websocket-servlet "9.2.9.v20150224"]]
   :deploy-repositories {"releases" :clojars})


### PR DESCRIPTION
See https://github.com/eclipse/jetty.project/blob/cfca172dd68846b2c7f30a9a6b855f08da7e7946/advisories/2015-02-24-httpparser-error-buffer-bleed.md for details.