### PR TITLE
Add flag to allow 'ensure trailing slash' behaviour to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ var ws = new WebSocket("ws://somehost/loc/");
 ws.onopen = ....
 ```
 
+If you want to omit the trailing slash from your URLs (and not receive a redirect from Jetty), you can start the server like:
+```clojure
+(run-jetty app {:websockets {"/loc" ws-handler}
+                :allow-null-path-info true})
+```
+
 ## Examples
 
 You can find examples in `examples` folder. To run example:

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -198,8 +198,9 @@
 
   "
   [handler {:as options
-            :keys [max-threads websockets configurator join? async?]
+            :keys [max-threads websockets configurator join? async? allow-null-path-info]
             :or {max-threads 50
+                 allow-null-path-info false
                  join? true}}]
   (let [^Server s (create-server options)
         ^QueuedThreadPool p (QueuedThreadPool. (int max-threads))
@@ -207,6 +208,7 @@
         ws-handlers (map (fn [[context-path handler]]
                            (doto (ContextHandler.)
                              (.setContextPath context-path)
+                             (.setAllowNullPathInfo allow-null-path-info)
                              (.setHandler (proxy-ws-handler handler options))))
                          websockets)
         contexts (doto (HandlerList.)


### PR DESCRIPTION
Jetty forces a trailing slash to the end of URLs, as mentioned in this project's README.md. This is achieved via a redirect and some browsers will fail to establish the WebSocket connection if this redirect is received.

This change allows Jetty's redirect to be disabled by setting `:allow-null-path-info true`. WebSocket connections can then be established with or without a trailing slash, and Jetty will not redirect.