### PR TITLE
Add :http? flag

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -153,6 +153,7 @@
          max-idle-time 200000
          ssl? false
          http? true}}]
+  {:pre [(or http? ssl? ssl-port)]}
   (let [pool (doto (QueuedThreadPool. (int max-threads)
                                       (int min-threads)
                                       (int threadpool-idle-timeout)

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -117,11 +117,33 @@
       nil)
     context))
 
+(defn- https-connector [server http-configuration ssl-context-factory h2? port host max-idle-time]
+  (let [secure-connection-factory (cond-> [(HttpConnectionFactory. http-configuration)]
+                                    h2? (concat [(ALPNServerConnectionFactory. "h2,h2-17,h2-14,http/1.1")
+                                                 (HTTP2ServerConnectionFactory. http-configuration)] ))]
+    (doto (ServerConnector.
+            ^Server server
+            ^SslContextFactory ssl-context-factory
+            (into-array ConnectionFactory secure-connection-factory))
+      (.setPort port)
+      (.setHost host)
+      (.setIdleTimeout max-idle-time))))
+
+(defn- http-connector [server http-configuration h2c? port host max-idle-time]
+  (let [plain-connection-factories (cond-> [(HttpConnectionFactory. http-configuration)]
+                                     h2c? (concat [(HTTP2CServerConnectionFactory. http-configuration)]))]
+    (doto (ServerConnector.
+            ^Server server
+            (into-array ConnectionFactory plain-connection-factories))
+      (.setPort port)
+      (.setHost host)
+      (.setIdleTimeout max-idle-time))))
+
 (defn- create-server
   "Construct a Jetty Server instance."
   [{:as options
     :keys [port max-threads min-threads threadpool-idle-timeout job-queue
-           daemon? max-idle-time host ssl? ssl-port h2? h2c?]
+           daemon? max-idle-time host ssl? ssl-port h2? h2c? http?]
     :or {port 80
          max-threads 50
          min-threads 8
@@ -129,7 +151,8 @@
          job-queue nil
          daemon? false
          max-idle-time 200000
-         ssl? false}}]
+         ssl? false
+         http? true}}]
   (let [pool (doto (QueuedThreadPool. (int max-threads)
                                       (int min-threads)
                                       (int threadpool-idle-timeout)
@@ -137,37 +160,13 @@
                (.setDaemon daemon?))
         server (doto (Server. pool)
                  (.addBean (ScheduledExecutorScheduler.)))
-
         http-configuration (http-config options)
-        plain-connection-factories (concat
-                                    (when h2c? [(HTTP2CServerConnectionFactory. http-configuration)])
-                                    [(HttpConnectionFactory. http-configuration)])
-        http-connector (doto (ServerConnector.
-                              ^Server server
-                              (into-array ConnectionFactory plain-connection-factories))
-                         (.setPort port)
-                         (.setHost host)
-                         (.setIdleTimeout max-idle-time))
-
-        secure-connection-factory (concat
-                                   (when h2?
-                                     [(ALPNServerConnectionFactory. "h2,h2-17,h2-14,http/1.1")
-                                      (HTTP2ServerConnectionFactory. http-configuration)])
-                                   [(HttpConnectionFactory. http-configuration)])
-        https-connector (when (or ssl? ssl-port)
-                          (doto (ServerConnector.
-                                 ^Server server
-                                 ^SslContextFactory(ssl-context-factory options)
-                                 (into-array ConnectionFactory secure-connection-factory))
-                            (.setPort ssl-port)
-                            (.setHost host)
-                            (.setIdleTimeout max-idle-time)))
-
-        connectors (concat
-                    (when https-connector [https-connector])
-                    [http-connector])
-        connectors (into-array connectors)]
-    (.setConnectors server connectors)
+        ssl? (or ssl? ssl-port)
+        connectors (cond-> []
+                     ssl?  (conj (https-connector server http-configuration (ssl-context-factory options)
+                                                  h2? ssl-port host max-idle-time))
+                     http? (conj (http-connector server http-configuration h2c? port host max-idle-time)))]
+    (.setConnectors server (into-array connectors))
     server))
 
 (defn ^Server run-jetty
@@ -175,6 +174,7 @@
   Start a Jetty webserver to serve the given handler according to the
   supplied options:
 
+  :http? - allow connections over HTTP
   :port - the port to listen on (defaults to 80)
   :host - the hostname to listen on
   :async? - using Ring 1.6 async handler?


### PR DESCRIPTION
Currently, it is not possible to call `run-jetty` without always running a HTTP connector. 

To have parity with the official `ring-jetty-adapter`, I have added a `http?` flag, which gives you the ability to only run an SSL HTTP connector - if that's what you desire. 