### PR TITLE
Allow headers to be added to error response

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -201,12 +201,12 @@
   :ws-max-idle-time  - the maximum idle time in milliseconds for a websocket connection (default 500000)
   :client-auth - SSL client certificate authenticate, may be set to :need, :want or :none (defaults to :none)
   :websockets - a map from context path to a map of handler fns:
-  {\"/context\" {:on-connect #(create-fn %)              ; ^Session ws-session
+   {\"/context\" {:on-connect #(create-fn %)              ; ^Session ws-session
                 :on-text   #(text-fn % %2 %3 %4)         ; ^Session ws-session message
                 :on-bytes  #(binary-fn % %2 %3 %4 %5 %6) ; ^Session ws-session payload offset len
                 :on-close  #(close-fn % %2 %3 %4)        ; ^Session ws-session statusCode reason
                 :on-error  #(error-fn % %2 %3)}}         ; ^Session ws-session e
-  or a custom creator function take upgrade request as parameter and returns a handler fns map (or error info)
+   or a custom creator function take upgrade request as parameter and returns a handler fns map (or error info)
   :h2? - enable http2 protocol on secure socket port
   :h2c? - enable http2 clear text on plain socket port
   :proxy? - enable the proxy protocol on plain socket port (see http://www.eclipse.org/jetty/documentation/9.4.x/configuring-connectors.html#_proxy_protocol)

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -1,4 +1,17 @@
-(ns ring.adapter.jetty9.common)
+(ns ring.adapter.jetty9.common
+  (:import [javax.servlet.http HttpServletResponse]))
 
 (defprotocol RequestMapDecoder
   (build-request-map [r]))
+
+(defn set-headers
+  "Update a HttpServletResponse with a map of headers."
+  [^HttpServletResponse response, headers]
+  (doseq [[key val-or-vals] headers]
+    (if (string? val-or-vals)
+      (.setHeader response key val-or-vals)
+      (doseq [val val-or-vals]
+        (.addHeader response key val))))
+  ; Some headers must be set through specific methods
+  (when-let [content-type (get headers "Content-Type")]
+    (.setContentType response content-type)))

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -121,8 +121,9 @@
     (createWebSocket [this req resp]
       (let [req-map (build-request-map req)
             ws-results (ws-creator-fn req-map)]
-        (if-let [{code :code msg :message} (:error ws-results)]
-          (.sendError resp code msg)
+        (if-let [{:keys [code message headers]} (:error ws-results)]
+          (do (set-headers resp headers)
+              (.sendError resp code message))
           (proxy-ws-adapter ws-results))))))
 
 (defn ^:internal proxy-ws-handler


### PR DESCRIPTION
Currently the ws-creator-fn is able to return an error object with status and message if it decides that the WebSocket should not be established. This change allows the ws-creator-fn to also include a `:headers` key in the returned error object, so that the error response has additional headers.

The `set-headers` function was taken from [ring-servlet](https://github.com/ring-clojure/ring/blob/6be2fc28195c6347c1394f44619325bc77e633fe/ring-servlet/src/ring/util/servlet.clj#L69). I opted to copy the code rather than refer to a private var. 