### PR TITLE
Fix #36 making http2 work again

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [org.eclipse.jetty.websocket/websocket-servlet ~jetty-version]
                  [org.eclipse.jetty.http2/http2-server ~jetty-version]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
-                 [org.eclipse.jetty/jetty-alpn-server ~jetty-version]]
+                 [org.eclipse.jetty/jetty-alpn-server ~jetty-version]
+                 [org.eclipse.jetty/jetty-alpn-openjdk8-server ~jetty-version]]
   :deploy-repositories {"releases" :clojars}
   :global-vars {*warn-on-reflection* true}
   :profiles {:example-http2 {:source-paths ["examples/"]


### PR DESCRIPTION
Add alpn-server for OpenJDK8 and reorder ciphers and protocols so that http/2 is preferred.