### PR TITLE
Support set max-text-message-size for web socket

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -226,6 +226,7 @@
   :job-queue - the job queue to be used by the Jetty threadpool (default is unbounded), ignored if `:thread-pool` provided
   :max-idle-time  - the maximum idle time in milliseconds for a connection (default 200000)
   :ws-max-idle-time  - the maximum idle time in milliseconds for a websocket connection (default 500000)
+  :ws-max-text-message-size  - the maximum text message size in bytes for a websocket connection (default 65536) 
   :client-auth - SSL client certificate authenticate, may be set to :need, :want or :none (defaults to :none)
   :websockets - a map from context path to a map of handler fns:
    {\"/context\" {:on-connect #(create-fn %)              ; ^Session ws-session

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -156,12 +156,15 @@
 (defn ^:internal proxy-ws-handler
   "Returns a Jetty websocket handler"
   [ws {:as options
-       :keys [ws-max-idle-time]
-       :or {ws-max-idle-time 500000}}]
+       :keys [ws-max-idle-time 
+              ws-max-text-message-size]
+       :or {ws-max-idle-time 500000
+            ws-max-text-message-size 65536}}]
   (proxy [WebSocketHandler] []
     (configure [^WebSocketServletFactory factory]
-      (-> (.getPolicy factory)
-          (.setIdleTimeout ws-max-idle-time))
+      (doto (.getPolicy factory)
+        (.setIdleTimeout ws-max-idle-time)
+        (.setMaxTextMessageSize ws-max-text-message-size))
       (.setCreator factory
                    (if (map? ws)
                      (reify-default-ws-creator ws)


### PR DESCRIPTION
Hi,

I propose to add a new option `:ws-max-text-message-size`, which makes it possible to set `max-text-message-size` for web socket handler.
