### PR TITLE
Allow for custom ws-adpater

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -9,7 +9,7 @@
            [org.eclipse.jetty.server.handler
             HandlerCollection AbstractHandler ContextHandler HandlerList]
            [org.eclipse.jetty.util.thread
-            QueuedThreadPool ScheduledExecutorScheduler]
+            QueuedThreadPool ScheduledExecutorScheduler ThreadPool]
            [org.eclipse.jetty.util.ssl SslContextFactory]
            [javax.servlet.http HttpServletRequest HttpServletResponse]
            [javax.servlet AsyncContext]
@@ -46,7 +46,7 @@
   "Returns an Jetty Handler implementation for the given Ring handler."
   [handler]
   (proxy [AbstractHandler] []
-    (handle [_ ^Request base-request request response]
+    (handle [_ ^Request base-request ^HttpServletRequest request ^HttpServletResponse response]
       (try
         (let [request-map (build-request-map request)
               response-map (-> (handler request-map)
@@ -62,7 +62,7 @@
   "Returns an Jetty Handler implementation for the given Ring **async** handler."
   [handler]
   (proxy [AbstractHandler] []
-    (handle [_ ^Request base-request request response]
+    (handle [_ ^Request base-request ^HttpServletRequest request ^HttpServletResponse response]
       (try
         (let [^AsyncContext context (.startAsync request)]
           (handler
@@ -186,7 +186,7 @@
                                           (int threadpool-idle-timeout)
                                           job-queue)
                    (.setDaemon daemon?)))
-        server (doto (Server. pool)
+        server (doto (Server. ^ThreadPool pool)
                  (.addBean (ScheduledExecutorScheduler.)))
         http-configuration (http-config options)
         ssl? (or ssl? ssl-port)

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -122,7 +122,7 @@
 (defprotocol IWebSocketAdapter
   (ws-adapter [this]))
 
-(defn- proxy-ws-adapter
+(defn proxy-ws-adapter
   [{:as ws-fns
     :keys [on-connect on-error on-text on-close on-bytes]
     :or {on-connect do-nothing

--- a/test/ring/adapter/jetty9_test.clj
+++ b/test/ring/adapter/jetty9_test.clj
@@ -11,8 +11,7 @@
    :on-error (fn [ws e])
    :on-text (fn [ws msg]
               (send! ws msg))
-   :on-byte (fn [ws bytes offset length]
-              )})
+   :on-byte (fn [ws bytes offset length])})
 
 (deftest jetty9-test
   (is (run-jetty dummy-app {:port 50524


### PR DESCRIPTION
Hi there,

We currently use [sente](https://github.com/ptaoussanis/sente) + [http-kit](https://github.com/http-kit/http-kit) for the project I am currently working on called [Operatr](http://operatr.io/). 

Long story short, we are very keen to ditch http-kit in favour of jetty.

We would still like to use sente, but the current implementation of websockets in this project make an adapter quite difficult.

The basic problem is that the only way to capture the instance of `WebSocketAdapter` is through one of the callback fns (eg, `on-connect`). 
Sente requires an instance of `WebSocketAdapter` one level up (as the return value of a handler fn), so it can manage the lifecycle of closing, sending msgs etc.

This PR adds the protocol `IWebSocketAdapter`, which has one method: `ws-adapter`. 

To maintain compatibility, all maps call `proxy-ws-adapter` as per-usual for their `ws-adapter` method.

This is enough to get an adapter for sente working, as seen in this [gist](https://gist.github.com/wavejumper/ba483412254bbda578b0119e9659d35a) (WIP)

If this PR looks reasonable, my next step will be to raise a PR in the sente project to include an adapter for ring-jetty9-adapter.

And while I was adding this protocol, I also fixed all reflection warnings I encountered :).