### PR TITLE
Add support for websocket protocol upgrade.

### DIFF
--- a/examples/rj9a/websocket_upgrade.clj
+++ b/examples/rj9a/websocket_upgrade.clj
@@ -1,0 +1,61 @@
+(ns rj9a.websocket-upgrade
+  (:gen-class)
+  (:require [ring.adapter.jetty9 :as jetty]))
+
+(defonce server (atom nil))
+
+(defn websocket-upgrade? [req]
+  (and (= (get-in req [:headers "upgrade"]) "websocket")
+       (= (get-in req [:headers "connection"]) "Upgrade")))
+
+(defn websocket-upgrade-response [ws-handler]
+  {:status 101 ;; http 101 switching protocols
+   :headers {"Upgrade" "websocket"
+             "Connection" "Upgrade"}
+   :ws ws-handler})
+
+(defn my-websocket-handler [_]
+  {:on-connect (fn on-connect [_]
+                 (tap> [:ws :connect]))
+   :on-text (fn on-text [ws text-message]
+              (tap> [:ws :msg text-message])
+              (jetty/send! ws (str "echo: " text-message)))
+   :on-bytes (fn on-bytes [_ _ _ _]
+               (tap> [:ws :bytes]))
+   :on-close (fn on-close [_ status-code reason]
+               (tap> [:ws :close status-code reason]))
+   :on-ping (fn on-ping [ws payload]
+              (tap> [:ws :ping])
+              (jetty/send! ws payload))
+   :on-pong (fn on-pong [_ _]
+              (tap> [:ws :pong]))
+   :on-error (fn on-error [_ e]
+               (tap> [:ws :error e]))})
+
+(defn handler [req]
+  (if (websocket-upgrade? req)
+    (websocket-upgrade-response my-websocket-handler)
+    {:status 200 :body "hello"}))
+
+(defn start! []
+  (when-not @server
+    (reset! server (jetty/run-jetty
+                    #'handler
+                    {:port 5000
+                     :join? false
+                     :allow-null-path-info true
+                     ;; The same ws can also be available via the old regular websocket endpoints.
+                     ;; It's added here in this example just for regression testing purposes.
+                     :websockets {"/mywebsocket" my-websocket-handler}}))))
+
+(defn stop! []
+  (when @server
+    (jetty/stop-server @server)
+    (reset! server nil)))
+
+(comment
+  (start!)
+  (stop!))
+
+(defn -main [& _]
+  (start!))

--- a/examples/rj9a/websocket_upgrade.clj
+++ b/examples/rj9a/websocket_upgrade.clj
@@ -1,17 +1,18 @@
 (ns rj9a.websocket-upgrade
   (:gen-class)
-  (:require [ring.adapter.jetty9 :as jetty]))
+  (:require [clojure.string :refer [lower-case]]
+            [ring.adapter.jetty9 :as jetty]))
 
 (defonce server (atom nil))
 
-(defn websocket-upgrade? [req]
-  (and (= (get-in req [:headers "upgrade"]) "websocket")
-       (= (get-in req [:headers "connection"]) "Upgrade")))
+(defn websocket-upgrade? [{:keys [headers]}]
+  (and (= "websocket" (lower-case (get headers "upgrade")))
+       (= "upgrade" (lower-case (get headers "connection")))))
 
 (defn websocket-upgrade-response [ws-handler]
   {:status 101 ;; http 101 switching protocols
-   :headers {"Upgrade" "websocket"
-             "Connection" "Upgrade"}
+   :headers {"upgrade" "websocket"
+             "connection" "upgrade"}
    :ws ws-handler})
 
 (defn my-websocket-handler [_]

--- a/examples/rj9a/websocket_upgrade.clj
+++ b/examples/rj9a/websocket_upgrade.clj
@@ -1,19 +1,9 @@
 (ns rj9a.websocket-upgrade
   (:gen-class)
-  (:require [clojure.string :refer [lower-case]]
-            [ring.adapter.jetty9 :as jetty]))
+  (:require [ring.adapter.jetty9 :as jetty]
+            [ring.adapter.jetty9.websocket :refer [ws-upgrade-request? ws-upgrade-response]]))
 
 (defonce server (atom nil))
-
-(defn websocket-upgrade? [{:keys [headers]}]
-  (and (= "websocket" (lower-case (get headers "upgrade")))
-       (= "upgrade" (lower-case (get headers "connection")))))
-
-(defn websocket-upgrade-response [ws-handler]
-  {:status 101 ;; http 101 switching protocols
-   :headers {"upgrade" "websocket"
-             "connection" "upgrade"}
-   :ws ws-handler})
 
 (defn my-websocket-handler [_]
   {:on-connect (fn on-connect [_]
@@ -34,8 +24,8 @@
                (tap> [:ws :error e]))})
 
 (defn handler [req]
-  (if (websocket-upgrade? req)
-    (websocket-upgrade-response my-websocket-handler)
+  (if (ws-upgrade-request? req)
+    (ws-upgrade-response my-websocket-handler)
     {:status 200 :body "hello"}))
 
 (defn start! []

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -53,46 +53,57 @@
          (and (= "websocket" (lower-case (get headers "upgrade")))
               (= "upgrade" (lower-case (get headers "connection")))))))
 
-(defn ^:internal proxy-handler
-  "Returns an Jetty Handler implementation for the given Ring handler."
-  [handler]
+(defn ^:internal wrap-proxy-handler
+  "Wraps a Jetty handler in a ServletContextHandler.
+   
+   Websocket upgrades require a servlet context which makes it
+   necessary to wrap the handler in a servlet context handler."
+  [jetty-handler]
   (doto (ServletContextHandler.)
     (.setContextPath "/*")
     (.setAllowNullPathInfo true)
     (JettyWebSocketServletContainerInitializer/configure nil)
-    (.setHandler
-     (proxy [AbstractHandler] []
-       (handle [_ ^Request base-request ^HttpServletRequest request ^HttpServletResponse response]
-         (try
-           (let [request-map (build-request-map request)
-                 response-map (-> (handler request-map)
-                                  normalize-response)]
-             (when response-map
-               (if (websocket-upgrade-response? response-map)
-                 (ws/upgrade-websocket request response (:ws response-map) {})
-                 (servlet/update-servlet-response response response-map))))
-           (catch Throwable e
-             (.sendError response 500 (.getMessage e)))
-           (finally
-             (.setHandled base-request true))))))))
+    (.setHandler jetty-handler)))
+
+(defn ^:internal proxy-handler
+  "Returns an Jetty Handler implementation for the given Ring handler."
+  [handler]
+  (wrap-proxy-handler
+   (proxy [AbstractHandler] []
+     (handle [_ ^Request base-request ^HttpServletRequest request ^HttpServletResponse response]
+       (try
+         (let [request-map (build-request-map request)
+               response-map (-> (handler request-map)
+                                normalize-response)]
+           (when response-map
+             (if (websocket-upgrade-response? response-map)
+               (ws/upgrade-websocket request response (:ws response-map) {})
+               (servlet/update-servlet-response response response-map))))
+         (catch Throwable e
+           (.sendError response 500 (.getMessage e)))
+         (finally
+           (.setHandled base-request true)))))))
 
 (defn ^:internal proxy-async-handler
   "Returns an Jetty Handler implementation for the given Ring **async** handler."
   [handler]
-  (proxy [AbstractHandler] []
-    (handle [_ ^Request base-request ^HttpServletRequest request ^HttpServletResponse response]
-      (try
-        (let [^AsyncContext context (.startAsync request)]
-          (handler
-           (servlet/build-request-map request)
-           (fn [response-map]
-             (let [response-map (normalize-response response-map)]
-               (servlet/update-servlet-response response context response-map)))
-           (fn [^Throwable exception]
-             (.sendError response 500 (.getMessage exception))
-             (.complete context))))
-        (finally
-          (.setHandled base-request true))))))
+  (wrap-proxy-handler
+   (proxy [AbstractHandler] []
+     (handle [_ ^Request base-request ^HttpServletRequest request ^HttpServletResponse response]
+       (try
+         (let [^AsyncContext context (.startAsync request)]
+           (handler
+            (servlet/build-request-map request)
+            (fn [response-map]
+              (let [response-map (normalize-response response-map)]
+                (if (websocket-upgrade-response? response-map)
+                  (ws/upgrade-websocket request response context (:ws response-map) {})
+                  (servlet/update-servlet-response response context response-map))))
+            (fn [^Throwable exception]
+              (.sendError response 500 (.getMessage exception))
+              (.complete context))))
+         (finally
+           (.setHandled base-request true)))))))
 
 (defn- http-config
   "Creates jetty http configurator"

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -30,3 +30,10 @@
              (string/join ","))))
     {}
     (enumeration-seq (.getHeaderNames request))))
+
+(defn lower-case-keys [m]
+  (->> m
+       (map #(if (string? (first %))
+               (update % 0 string/lower-case)
+               %))
+       (into {})))

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -218,8 +218,12 @@
    - upgrade: websocket
   "
   [{:keys [headers] :as _request-map}]
-  (and (= "websocket" (lower-case (get headers "upgrade")))
-       (= "upgrade" (lower-case (get headers "connection")))))
+  (let [upgrade (get headers "upgrade")
+        connection (get headers "connection")]
+    (and upgrade
+         connection
+         (= "websocket" (lower-case upgrade))
+         (= "upgrade" (lower-case connection)))))
 
 (defn ws-upgrade-response
   "Returns a websocket upgrade response.


### PR DESCRIPTION
A ring handler can detect a websocket protocol upgrade request by inspecting the `Connection` and `Upgrade` headers. Then the ring handler may decide to proceed with the upgrade by returning HTTP status 101 (Switching Protocols) with the appropriate websocket upgrade response headers. Then the ring adapter automatically upgrades the HTTP request to a websocket connection. In this case the ring adapter expects the response map to have a `:ws` key containing the websocket handler.

The motivation here is to allow clients to connect on the same URI path for regular HTTP calls as well as websockets. E.g. GraphQL clients typically connect on the same URI path (e.g. `/graphql`) for running queries and making subscriptions over websocket.

Two unresolved issues in this PR:

* ~~`websocket-upgrade-response?` is case-sensitive with regards to reading the response headers.~~ (done).
* ~~The protocol upgrade support needs to be replicated in `proxy-async-handler`~~ (done).

I'm planning to fix those two issues in case you approve this draft. There might be other issues that escaped me that you'll probably catch. Please let me know.

More information on switching protocols at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101
