### PR TITLE
feat: implement http3 connector

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -16,6 +16,8 @@ jobs:
         graalvm-version: '21.0.0.java11'
     - uses: DeLaGuardo/setup-clojure@master
       with:
-        lein: 2.9.5
+        lein: 2.9.8
+    - name: Install modules
+      run: cd http3; lein install
     - name: Run tests
       run: lein test

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ options to `run-jetty` like:
 
 ### HTTP/3
 
-From 10.0.8, Jetty ships an expiremental HTTP/3 implementation based
-on [the quiche library](https://github.com/cloudflare/quiche). rj9a
-made it an optional feature. To enable HTTP/3 support, you will need
-to:
+From 10.0.9, Jetty ships a usable expiremental HTTP/3 implementation
+based on [the quiche
+library](https://github.com/cloudflare/quiche). rj9a made it an
+optional feature. To enable HTTP/3 support, you will need to:
 
-* Install libquiche 0.11.0 on your system and make sure `libquiche.so`
-  can be loaded from the Clojure(Java) application.
+* Install libquiche on your system and make sure `libquiche.so` can be
+  loaded from the Clojure(Java) application.
 * In addition to rj9a, add dependency
   `[info.sunng/ring-jetty9-adapter-http3 "0.1.0"]` to your clojure
   project to bring in HTTP/3 staff.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ring-jetty9-adapter (rj9a)
 
-Ring adapter for Jetty 9 and above versions, with HTTP2 and WebSocket support.
+Ring adapter for Jetty 10 and above versions, with HTTP/3, WebSocket and
+Expiremental HTTP/3 support.
 
 This is a simple and plain wrapper on Jetty 9. It doesn't introduce
 additional thread model or anything else (no unofficial ring variance,
@@ -79,6 +80,37 @@ options to `run-jetty` like:
                             :key-password "111111"
                             :keystore-type "jks"})
 ```
+
+### HTTP/3
+
+From 10.0.8, Jetty ships an expiremental HTTP/3 implementation based
+on [the quiche library](https://github.com/cloudflare/quiche). rj9a
+made it an optional feature. To enable HTTP/3 support, you will need
+to:
+
+* Install libquiche 0.11.0 on your system and make sure `libquiche.so`
+  can be loaded from the Clojure(Java) application.
+* In addition to rj9a, add dependency
+  `[info.sunng/ring-jetty9-adapter-http3 "0.1.0"]` to your clojure
+  project to bring in HTTP/3 staff.
+* Provide certficate and key just like HTTPs setup because HTTP/3 is
+  secure by default. There is no plaintext fallback for now.
+* Provide option `:http3? true` to `run-jetty` to enable HTTP/3
+  protocol.
+
+```clojure
+(jetty/run-jetty dummy-app {:port 5000  ;; default clear-text http/1.1 port
+                            :http3 true  ;; enable http/3 support
+                            :ssl-port 5443 ;; ssl-port is used by http/3
+                            :keystore "dev-resources/keystore.jks"
+                            :key-password "111111"
+                            :keystore-type "jks"})
+```
+
+Since HTTP/3 runs on UDP, it could share same port with TCP based
+protocol like HTTP/2 or 1.1.
+
+An example is available in `examples` folder.
 
 ### WebSocket
 
@@ -168,6 +200,7 @@ You can find examples in `examples` folder. To run example:
 * async: `lein with-profile example-async run` ring 1.6 async
   handler example
 * http2 `lein with-profile example-http2 run`
+* http3 `lein with-profile example-http3 run`
 * websocket: `lein with-profile example-websocket run`
 
 ## Contributors

--- a/dev-resources/simplelogger.properties
+++ b/dev-resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug

--- a/examples/rj9a/http3.clj
+++ b/examples/rj9a/http3.clj
@@ -1,0 +1,12 @@
+(ns rj9a.http3
+  (:gen-class)
+  (:require [ring.adapter.jetty9 :as jetty]))
+
+(defn dummy-app [req] {:body "It works" :status 200})
+
+(defn -main [& args]
+  (jetty/run-jetty dummy-app {:port 5000 :http false :http3? true :ssl-port 5443
+                              :keystore "dev-resources/keystore.jks"
+                              :key-password "111111"
+                              :keystore-type "jks"
+                              :sni-host-check? false}))

--- a/http3/.gitignore
+++ b/http3/.gitignore
@@ -1,0 +1,17 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-repl-history
+.lein-env
+
+.idea/
+*.iml
+/.nrepl-port

--- a/http3/project.clj
+++ b/http3/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "10.0.9-SNAPSHOT")
+(def jetty-version "10.0.9")
 
 (defproject info.sunng/ring-jetty9-adapter-http3 "0.1.0-SNAPSHOT"
   :description "Ring adapter for jetty 9 and above, meta package for http3"

--- a/http3/project.clj
+++ b/http3/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "10.0.8")
+(def jetty-version "10.0.9-SNAPSHOT")
 
 (defproject info.sunng/ring-jetty9-adapter-http3 "0.1.0-SNAPSHOT"
   :description "Ring adapter for jetty 9 and above, meta package for http3"

--- a/http3/project.clj
+++ b/http3/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "10.0.8")
 
-(defproject info.sunng/ring-jetty9-adapter-http3 "0.18.0-SNAPSHOT"
+(defproject info.sunng/ring-jetty9-adapter-http3 "0.1.0-SNAPSHOT"
   :description "Ring adapter for jetty 9 and above, meta package for http3"
   :url "http://github.com/sunng87/ring-jetty9-adapter"
   :license {:name "Eclipse Public License"

--- a/http3/project.clj
+++ b/http3/project.clj
@@ -1,0 +1,10 @@
+(def jetty-version "10.0.8")
+
+(defproject info.sunng/ring-jetty9-adapter-http3 "0.18.0-SNAPSHOT"
+  :description "Ring adapter for jetty 9 and above, meta package for http3"
+  :url "http://github.com/sunng87/ring-jetty9-adapter"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :deploy-repositories {"releases" :clojars}
+  :global-vars {*warn-on-reflection* true}
+  :dependencies [[org.eclipse.jetty.http3/http3-server ~jetty-version]])

--- a/http3/src/ring/adapter/jetty9/http3.clj
+++ b/http3/src/ring/adapter/jetty9/http3.clj
@@ -5,10 +5,8 @@
             HTTP3ServerConnectionFactory HTTP3ServerConnector]
            [org.eclipse.jetty.http3.api Session$Server$Listener]))
 
-(defn http3-connector [server ssl-context-factory port host]
-  (let [http-config (doto (HttpConfiguration.)
-                      (.addCustomizer (SecureRequestCustomizer.)))
-        connection-factory (HTTP3ServerConnectionFactory. http-config)
+(defn http3-connector [server http-configuration ssl-context-factory port host]
+  (let [connection-factory (HTTP3ServerConnectionFactory. http-configuration)
         connector (HTTP3ServerConnector. server ssl-context-factory
                                          (into-array HTTP3ServerConnectionFactory [connection-factory]))]
     (doto connector

--- a/http3/src/ring/adapter/jetty9/http3.clj
+++ b/http3/src/ring/adapter/jetty9/http3.clj
@@ -1,13 +1,16 @@
 (ns ring.adapter.jetty9.http3
-  (:import [org.eclipse.jetty.http3.server
-            RawHTTP3ServerConnectionFactory HTTP3ServerConnector]
+  (:import [org.eclipse.jetty.server
+            HttpConfiguration SecureRequestCustomizer]
+           [org.eclipse.jetty.http3.server
+            HTTP3ServerConnectionFactory HTTP3ServerConnector]
            [org.eclipse.jetty.http3.api Session$Server$Listener]))
 
 (defn http3-connector [server ssl-context-factory port host]
-  (let [listener (reify Session$Server$Listener)
-        connection-factory (RawHTTP3ServerConnectionFactory. listener)
+  (let [http-config (doto (HttpConfiguration.)
+                      (.addCustomizer (SecureRequestCustomizer.)))
+        connection-factory (HTTP3ServerConnectionFactory. http-config)
         connector (HTTP3ServerConnector. server ssl-context-factory
-                                         (into-array RawHTTP3ServerConnectionFactory [connection-factory]))]
+                                         (into-array HTTP3ServerConnectionFactory [connection-factory]))]
     (doto connector
       (.setPort port)
       (.setHost host))))

--- a/http3/src/ring/adapter/jetty9/http3.clj
+++ b/http3/src/ring/adapter/jetty9/http3.clj
@@ -1,0 +1,13 @@
+(ns ring.adapter.jetty9.http3
+  (:import [org.eclipse.jetty.http3.server
+            RawHTTP3ServerConnectionFactory HTTP3ServerConnector]
+           [org.eclipse.jetty.http3.api Session$Server$Listener]))
+
+(defn http3-connector [server ssl-context-factory port host]
+  (let [listener (reify Session$Server$Listener)
+        connection-factory (RawHTTP3ServerConnectionFactory. listener)
+        connector (HTTP3ServerConnector. server ssl-context-factory
+                                         (into-array RawHTTP3ServerConnectionFactory [connection-factory]))]
+    (doto connector
+      (.setPort port)
+      (.setHost host))))

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,6 @@
                  [org.eclipse.jetty.websocket/websocket-jetty-server ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-servlet ~jetty-version]
                  [org.eclipse.jetty.http2/http2-server ~jetty-version]
-                 [org.eclipse.jetty.http3/http3-server ~jetty-version]
                  [org.eclipse.jetty/jetty-alpn-server ~jetty-version]
                  [org.eclipse.jetty/jetty-alpn-java-server ~jetty-version]]
   :deploy-repositories {"releases" :clojars}

--- a/project.clj
+++ b/project.clj
@@ -6,12 +6,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [ring/ring-servlet "1.9.4"]
+                 [ring/ring-servlet "1.9.5" :exclusions [commons-io]]
                  [org.eclipse.jetty/jetty-server ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-jetty-api ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-jetty-server ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-servlet ~jetty-version]
                  [org.eclipse.jetty.http2/http2-server ~jetty-version]
+                 [org.eclipse.jetty.http3/http3-server ~jetty-version]
                  [org.eclipse.jetty/jetty-alpn-server ~jetty-version]
                  [org.eclipse.jetty/jetty-alpn-java-server ~jetty-version]]
   :deploy-repositories {"releases" :clojars}
@@ -23,6 +24,8 @@
                                   #_[stylefruits/gniazdo "1.1.4"]]}
              :example-http2 {:source-paths ["examples/"]
                              :main ^:skip-aot rj9a.http2}
+             :example-http3 {:source-paths ["examples/"]
+                             :main ^:skip-aot rj9a.http3}
              :example-websocket {:source-paths ["examples/"]
                                  :main ^:skip-aot rj9a.websocket}
              :example-http {:source-paths ["examples/"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "10.0.8")
+(def jetty-version "10.0.9-SNAPSHOT")
 
 (defproject info.sunng/ring-jetty9-adapter "0.17.6-SNAPSHOT"
   :description "Ring adapter for jetty9, which supports websocket and spdy"
@@ -20,7 +20,7 @@
   :jvm-args ["-Xmx128m"]
   :profiles {:dev {:dependencies [[clj-http "3.12.3"]
                                   [less-awful-ssl "1.0.6"]
-                                  [org.slf4j/slf4j-simple "2.0.0-alpha5"]
+                                  [org.slf4j/slf4j-simple "2.0.0-alpha6"]
                                   #_[stylefruits/gniazdo "1.1.4"]]}
              :example-http2 {:source-paths ["examples/"]
                              :main ^:skip-aot rj9a.http2}

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [ring/ring-servlet "1.9.5" :exclusions [commons-io]]
+                 [info.sunng/ring-jetty9-adapter-http3 "0.1.0-SNAPSHOT" :optional true]
                  [org.eclipse.jetty/jetty-server ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-jetty-api ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-jetty-server ~jetty-version]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "10.0.9-SNAPSHOT")
+(def jetty-version "10.0.9")
 
 (defproject info.sunng/ring-jetty9-adapter "0.17.6-SNAPSHOT"
   :description "Ring adapter for jetty9, which supports websocket and spdy"

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -217,15 +217,6 @@
       (.setHost host)
       (.setIdleTimeout max-idle-time))))
 
-;; (defn- http3-connector [server ssl-context-factory port host]
-;;   (let [listener (reify Session$Server$Listener)
-;;         connection-factory (RawHTTP3ServerConnectionFactory. listener)
-;;         connector (HTTP3ServerConnector. server ssl-context-factory
-;;                                          (into-array RawHTTP3ServerConnectionFactory [connection-factory]))]
-;;     (doto connector
-;;       (.setPort port)
-;;       (.setHost host))))
-
 (defn- http3-connector [& args]
   ;; load http3 module dynamically
   (require 'ring.adapter.jetty9.http3)
@@ -264,7 +255,7 @@
                      ssl?  (conj (https-connector server http-configuration ssl-factory
                                                   h2? ssl-port host max-idle-time))
                      http? (conj (http-connector server http-configuration h2c? port host max-idle-time proxy?))
-                     http3? (conj (http3-connector server ssl-factory ssl-port host)))]
+                     http3? (conj (http3-connector server http-configuration ssl-factory ssl-port host)))]
     (.setConnectors server (into-array Connector connectors))
     server))
 


### PR DESCRIPTION
Tasks before merging this:

- [x] adding example for http/3
- [x] quic-quiche-foreign-incubator missing from maven central https://github.com/eclipse/jetty.project/issues/7557
- [x] make http3 and its dependency optional, activated via a meta package
- [x] fix jetty-quic that has mutual tls turned on by default https://github.com/eclipse/jetty.project/pull/7574
- [x] IOException: unconsumed content
- [x] adding docs for http/3
- [x] waiting for jetty 10.0.9 release for fixes above

Fixes #68 