### PR TITLE
Jetty 11 Support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "10.0.12")
+(def jetty-version "11.0.12")
 
 (defproject info.sunng/ring-jetty9-adapter "0.17.10-SNAPSHOT"
   :description "Ring adapter for jetty9, which supports websocket and spdy"

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [ring/ring-servlet "1.9.6" :exclusions [commons-io]]
+                 [ring/ring-core "1.9.6" :exclusions [commons-io]]
                  [info.sunng/ring-jetty9-adapter-http3 "0.1.1" :optional true]
                  [org.eclipse.jetty/jetty-server ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-jetty-api ~jetty-version]

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -12,8 +12,8 @@
             QueuedThreadPool ScheduledExecutorScheduler ThreadPool]
            [org.eclipse.jetty.util.ssl SslContextFactory SslContextFactory$Server]
            [org.eclipse.jetty.websocket.server.config JettyWebSocketServletContainerInitializer]
-           [javax.servlet.http HttpServletRequest HttpServletResponse]
-           [javax.servlet AsyncContext]
+           [jakarta.servlet.http HttpServletRequest HttpServletResponse]
+           [jakarta.servlet AsyncContext]
            [org.eclipse.jetty.http2 HTTP2Cipher]
            [org.eclipse.jetty.http2.server
             HTTP2CServerConnectionFactory HTTP2ServerConnectionFactory]

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -20,8 +20,8 @@
            [org.eclipse.jetty.alpn.server ALPNServerConnectionFactory]
            [java.security KeyStore])
   (:require [clojure.string :as string]
-            [ring.util.servlet :as servlet]
             [ring.adapter.jetty9.common :refer [RequestMapDecoder build-request-map]]
+            [ring.adapter.jetty9.servlet :as servlet]
             [ring.adapter.jetty9.websocket :as ws]))
 
 (def send! ws/send!)

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -1,6 +1,6 @@
 (ns ring.adapter.jetty9.common
   (:require [clojure.string :as string])
-  (:import [javax.servlet.http HttpServletRequest HttpServletResponse]
+  (:import [jakarta.servlet.http HttpServletRequest HttpServletResponse]
            [java.util Locale]))
 
 (defprotocol RequestMapDecoder

--- a/src/ring/adapter/jetty9/servlet.clj
+++ b/src/ring/adapter/jetty9/servlet.clj
@@ -2,8 +2,8 @@
   (:require [clojure.string :as string]
             [ring.adapter.jetty9.common :as common]
             [ring.core.protocols :as protocols])
-  (:import [javax.servlet AsyncContext]
-           [javax.servlet.http HttpServletRequest HttpServletResponse]
+  (:import [jakarta.servlet AsyncContext]
+           [jakarta.servlet.http HttpServletRequest HttpServletResponse]
            [java.util Locale]))
 
 (defn- get-content-length
@@ -15,7 +15,7 @@
 (defn- get-client-cert
   "Returns the SSL client certificate of the request, if one exists."
   [^HttpServletRequest request]
-  (first (.getAttribute request "javax.servlet.request.X509Certificate")))
+  (first (.getAttribute request "jakarta.servlet.request.X509Certificate")))
 
 (defn build-request-map
   "Create the request map from the HttpServletRequest object."

--- a/src/ring/adapter/jetty9/servlet.clj
+++ b/src/ring/adapter/jetty9/servlet.clj
@@ -1,0 +1,66 @@
+(ns ring.adapter.jetty9.servlet
+  (:require [clojure.string :as string]
+            [ring.adapter.jetty9.common :as common]
+            [ring.core.protocols :as protocols])
+  (:import [javax.servlet AsyncContext]
+           [javax.servlet.http HttpServletRequest HttpServletResponse]
+           [java.util Locale]))
+
+(defn- get-content-length
+  "Returns the content length, or nil if there is no content."
+  [^HttpServletRequest request]
+  (let [length (.getContentLength request)]
+    (if (>= length 0) length)))
+
+(defn- get-client-cert
+  "Returns the SSL client certificate of the request, if one exists."
+  [^HttpServletRequest request]
+  (first (.getAttribute request "javax.servlet.request.X509Certificate")))
+
+(defn build-request-map
+  "Create the request map from the HttpServletRequest object."
+  [^HttpServletRequest request]
+  {:server-port        (.getServerPort request)
+   :server-name        (.getServerName request)
+   :remote-addr        (.getRemoteAddr request)
+   :uri                (.getRequestURI request)
+   :query-string       (.getQueryString request)
+   :scheme             (keyword (.getScheme request))
+   :request-method     (keyword (.toLowerCase (.getMethod request) Locale/ENGLISH))
+   :protocol           (.getProtocol request)
+   :headers            (common/get-headers request)
+   :content-type       (.getContentType request)
+   :content-length     (get-content-length request)
+   :character-encoding (.getCharacterEncoding request)
+   :ssl-client-cert    (get-client-cert request)
+   :body               (.getInputStream request)})
+
+(defn- make-output-stream
+  [^HttpServletResponse response ^AsyncContext context]
+  (let [os (.getOutputStream response)]
+    (if (nil? context)
+      os
+      (proxy [java.io.FilterOutputStream] [os]
+        (write
+          ([b]         (.write os b))
+          ([b off len] (.write os b off len)))
+        (close []
+          (.close os)
+          (.complete context))))))
+
+(defn update-servlet-response
+  "Update the HttpServletResponse using a response map. Takes an optional
+  AsyncContext."
+  ([response response-map]
+   (update-servlet-response response nil response-map))
+  ([^HttpServletResponse response context response-map]
+   (let [{:keys [status headers body]} response-map]
+     (when (nil? response)
+       (throw (NullPointerException. "HttpServletResponse is nil")))
+     (when (nil? response-map)
+       (throw (NullPointerException. "Response map is nil")))
+     (when status
+       (.setStatus response status))
+     (common/set-headers response headers)
+     (let [output-stream (make-output-stream response context)]
+       (protocols/write-body-to-stream body response-map output-stream)))))

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -6,8 +6,8 @@
            [org.eclipse.jetty.websocket.server JettyWebSocketServerContainer
             JettyWebSocketCreator JettyServerUpgradeRequest]
            [org.eclipse.jetty.websocket.common JettyExtensionConfig]
-           [javax.servlet AsyncContext]
-           [javax.servlet.http HttpServlet HttpServletRequest HttpServletResponse]
+           [jakarta.servlet AsyncContext]
+           [jakarta.servlet.http HttpServlet HttpServletRequest HttpServletResponse]
            [clojure.lang IFn]
            [java.nio ByteBuffer]
            [java.util Locale]
@@ -105,7 +105,7 @@
                             :protocol (.getProtocol servlet-request)
                             :headers (get-headers servlet-request)
                             :ssl-client-cert (first (.getAttribute servlet-request
-                                                                   "javax.servlet.request.X509Certificate"))}]
+                                                                   "jakarta.servlet.request.X509Certificate"))}]
       (assoc base-request-map
              :websocket-subprotocols (into [] (.getSubProtocols request))
              :websocket-extensions (into [] (.getExtensions request))))))


### PR DESCRIPTION
This migrates the code over to Jetty 11. The javax.servlet package is renamed to jakarta.servlet in Jetty 11. To support this, the ring.util.servlet dependency is removed (which imports the deprecated javax.servlet package), and the required code is copied over into ring.adapter.jetty9.servlet.