### PR TITLE
fix: allow both string and ExtensionConfig for :extensions

### DIFF
--- a/examples/rj9a/websocket.clj
+++ b/examples/rj9a/websocket.clj
@@ -25,7 +25,7 @@
      ;; select subprotocol
      :subprotocol (first provided-subprotocols)
      ;; exntension negotiation
-     :extentions provided-extensions}))
+     :extensions provided-extensions}))
 
 (defn handler [req]
   (if (jetty/ws-upgrade-request? req)

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -185,7 +185,10 @@
             (when-let [sp (:subprotocol ws-results)]
               (.setAcceptedSubProtocol resp sp))
             (when-let [exts (not-empty (:extensions ws-results))]
-              (.setExtensions resp (mapv #(JettyExtensionConfig. ^String %) exts)))
+              (.setExtensions resp (mapv #(if (string? %)
+                                            (JettyExtensionConfig. ^String %)
+                                            %)
+                                         exts)))
             (proxy-ws-adapter ws-results)))))))
 
 (defn upgrade-websocket


### PR DESCRIPTION
Fixes #79 

`:extensions` from websocket handshake handler result was suffering a type issue, that we treated `JettyExtensionConfig` from `UpgradeRequest` as string. In this patch we supported both string and `JettyExtensionConfig` so that user can either forward it from request map, or create their own as string.
