### PR TITLE
fix: correct/add type hints to avoid reflection

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -198,9 +198,9 @@
                                                      (HTTP2ServerConnectionFactory. http-configuration)])
                                           [(HttpConnectionFactory. http-configuration)])]
     (doto (ServerConnector.
-           ^Server server
-           ^SslContextFactory ssl-context-factory
-           ^"[Lorg.eclipse.jetty.server.ConnectionFactory;" (into-array ConnectionFactory secure-connection-factory))
+            ^Server server
+            ^SslContextFactory$Server ssl-context-factory
+            ^"[Lorg.eclipse.jetty.server.ConnectionFactory;" (into-array ConnectionFactory secure-connection-factory))
       (.setPort port)
       (.setHost host)
       (.setIdleTimeout max-idle-time))))

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -198,9 +198,9 @@
                                                      (HTTP2ServerConnectionFactory. http-configuration)])
                                           [(HttpConnectionFactory. http-configuration)])]
     (doto (ServerConnector.
-            ^Server server
-            ^SslContextFactory$Server ssl-context-factory
-            ^"[Lorg.eclipse.jetty.server.ConnectionFactory;" (into-array ConnectionFactory secure-connection-factory))
+           ^Server server
+           ^SslContextFactory$Server ssl-context-factory
+           ^"[Lorg.eclipse.jetty.server.ConnectionFactory;" (into-array ConnectionFactory secure-connection-factory))
       (.setPort port)
       (.setHost host)
       (.setIdleTimeout max-idle-time))))

--- a/src/ring/adapter/jetty9/servlet.clj
+++ b/src/ring/adapter/jetty9/servlet.clj
@@ -42,7 +42,7 @@
       os
       (proxy [java.io.FilterOutputStream] [os]
         (write
-          ([b]         (.write os b))
+          ([b]         (.write os ^bytes b))
           ([b off len] (.write os b off len)))
         (close []
           (.close os)


### PR DESCRIPTION
Just some small metadata changes that should remove the reliance on runtime reflection for this library to work. This should allow a project using HTTPS and GraalVM to stick to the publicly known reachability metadata - https://github.com/oracle/graalvm-reachability-metadata/tree/master/metadata/org.eclipse.jetty/jetty-server/11.0.12