### PR TITLE
Compilation issues do to missing dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,9 @@
                  [org.eclipse.jetty.websocket/websocket-servlet ~jetty-version]
                  [org.eclipse.jetty.http2/http2-server ~jetty-version]
                  [org.eclipse.jetty/jetty-alpn-server ~jetty-version]
-                 [org.eclipse.jetty/jetty-alpn-java-server ~jetty-version]]
+                 [org.eclipse.jetty/jetty-alpn-java-server ~jetty-version]
+                 [org.eclipse.jetty/jetty-util ~jetty-version]
+                 [org.eclipse.jetty/jetty-http ~jetty-version]]
   :deploy-repositories {"releases" :clojars}
   :global-vars {*warn-on-reflection* true}
   :jvm-args ["-Xmx128m"]


### PR DESCRIPTION
I cannot seem to get my project to build with this library unless I manually add these dependencies. I could be doing something totally wrong; sorry for the noise if so. 

Thank you for this project!

Here are the two compilation issues I run into: 
```
Exception in thread "main" Unexpected error macroexpanding proxy at (ring/adapter/jetty9.clj:72:4).
...
Caused by: java.lang.NoClassDefFoundError: org/eclipse/jetty/util/thread/AutoLock
```

```
Exception in thread "main" Unexpected error macroexpanding proxy at (ring/adapter/jetty9.clj:72:4).
...
Caused by: java.lang.NoClassDefFoundError: org/eclipse/jetty/http/HttpFields$Immutable
```