### PR TITLE
fix: add default value for ssl-port if ssl? enabled

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -250,6 +250,7 @@
                  (.addBean (ScheduledExecutorScheduler.)))
         http-configuration (http-config options)
         ssl? (or ssl? ssl-port)
+        ssl-port (or ssl-port (when ssl? 443))
         ssl-factory (ssl-context-factory options)
         connectors (cond-> []
                      ssl?  (conj (https-connector server http-configuration ssl-factory


### PR DESCRIPTION
Fixes #85 

If `ssl?` is specifies, we provide default value `443` to `ssl-port`