### PR TITLE
Http2 options

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -23,10 +23,10 @@
            [java.security KeyStore]
            [ring.adapter.jetty9.handlers SyncProxyHandler AsyncProxyHandler])
   (:require
-   [clojure.string :as string]
-   [ring.adapter.jetty9.common :refer [RequestMapDecoder]]
-   [ring.adapter.jetty9.servlet :as servlet]
-   [ring.adapter.jetty9.websocket :as ws]))
+    [clojure.string :as string]
+    [ring.adapter.jetty9.common :refer [RequestMapDecoder]]
+    [ring.adapter.jetty9.servlet :as servlet]
+    [ring.adapter.jetty9.websocket :as ws]))
 
 (def send! ws/send!)
 (def ping! ws/ping!)
@@ -60,13 +60,13 @@
   "Returns a Jetty Handler implementation for the given Ring handler."
   [handler options]
   (wrap-proxy-handler
-   (SyncProxyHandler. handler options)))
+    (SyncProxyHandler. handler options)))
 
 (defn ^:internal proxy-async-handler
   "Returns a Jetty Handler implementation for the given Ring **async** handler."
   [handler options]
   (wrap-proxy-handler
-   (AsyncProxyHandler. handler options)))
+    (AsyncProxyHandler. handler options)))
 
 (defn- http-config
   "Creates jetty http configurator"
@@ -350,9 +350,9 @@
                  wrap-jetty-handler identity}}]
   (let [^Server s (create-server options)
         ring-app-handler (wrap-jetty-handler
-                          (if async?
-                            (proxy-async-handler handler options)
-                            (proxy-handler handler options)))]
+                           (if async?
+                             (proxy-async-handler handler options)
+                             (proxy-handler handler options)))]
     (.setHandler s ring-app-handler)
     (when-let [c configurator]
       (c s))

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -237,8 +237,6 @@
       (.setHost host)
       (.setIdleTimeout max-idle-time))))
 
-(boolean? true)
-
 (defn- http3-connector [& args]
   ;; load http3 module dynamically
   (let [http3-connector* @(requiring-resolve 'ring.adapter.jetty9.http3/http3-connector)]

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -210,7 +210,7 @@
 
 (defn- https-connector [server http-configuration ssl-context-factory h2? h2-options port host max-idle-time]
   (let [secure-connection-factory (concat (when h2? [(ALPNServerConnectionFactory. "h2,http/1.1")
-                                                     (-> (HTTP2ServerConnectionFactory http-configuration)
+                                                     (-> (HTTP2ServerConnectionFactory. http-configuration)
                                                          (http2-server-connection-factory h2-options))])
                                           [(HttpConnectionFactory. http-configuration)])]
     (doto (ServerConnector.

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -167,45 +167,48 @@
                  max-frame-length max-header-block-fragment max-setting-keys
                  ^RateControl$Factory rate-control-factory
                  stream-idle-timeout use-input-direct-byte-buffers use-output-direct-byte-buffers]}
-         h2-options]
+         h2-options
+         
+         option-provided?
+         #(contains? h2-options %)]
      (cond-> factory-from-http-config
-       (boolean? connect-protocol-enabled)
+       (option-provided? :connect-protocol-enabled)
        (doto (.setConnectProtocolEnabled connect-protocol-enabled))
 
-       (contains? h2-options :flow-control-strategy-factory)
+       (option-provided? :flow-control-strategy-factory)
        (doto (.setFlowControlStrategyFactory flow-control-strategy-factory))
 
-       initial-session-recv-window
+       (option-provided? :initial-session-recv-window)
        (doto (.setInitialSessionRecvWindow initial-session-recv-window))
 
-       initial-stream-recv-window
+       (option-provided? :initial-stream-recv-window)
        (doto (.setInitialStreamRecvWindow initial-stream-recv-window))
 
-       max-concurrent-streams
+       (option-provided? :max-concurrent-streams)
        (doto (.setMaxConcurrentStreams max-concurrent-streams))
 
-       max-dynamic-table-size
+       (option-provided? :max-dynamic-table-size)
        (doto (.setMaxDynamicTableSize max-dynamic-table-size))
 
-       max-frame-length
+       (option-provided? :max-frame-length)
        (doto (.setMaxFrameLength max-frame-length))
 
-       max-header-block-fragment
+       (option-provided? :max-header-block-fragment)
        (doto (.setMaxHeaderBlockFragment max-header-block-fragment))
 
-       max-setting-keys
+       (option-provided? :max-setting-keys)
        (doto (.setMaxSettingsKeys max-setting-keys))
 
-       rate-control-factory
+       (option-provided? :rate-control-factory)
        (doto (.setRateControlFactory rate-control-factory))
 
-       stream-idle-timeout
+       (option-provided? :stream-idle-timeout)
        (doto (.setStreamIdleTimeout stream-idle-timeout))
 
-       (boolean? use-input-direct-byte-buffers)
+       (option-provided? :use-input-direct-byte-buffers)
        (doto (.setUseInputDirectByteBuffers use-input-direct-byte-buffers))
 
-       (boolean? use-output-direct-byte-buffers)
+       (option-provided? :use-output-direct-byte-buffers)
        (doto (.setUseOutputDirectByteBuffers use-output-direct-byte-buffers))))))
 
 (defn- https-connector [server http-configuration ssl-context-factory h2? h2-options port host max-idle-time]

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -172,7 +172,7 @@
        (boolean? connect-protocol-enabled)
        (doto (.setConnectProtocolEnabled connect-protocol-enabled))
 
-       flow-control-strategy-factory
+       (contains? h2-options :flow-control-strategy-factory)
        (doto (.setFlowControlStrategyFactory flow-control-strategy-factory))
 
        initial-session-recv-window

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -169,7 +169,7 @@
                  stream-idle-timeout use-input-direct-byte-buffers use-output-direct-byte-buffers]}
          h2-options]
      (cond-> factory-from-http-config
-       connect-protocol-enabled
+       (boolean? connect-protocol-enabled)
        (doto (.setConnectProtocolEnabled connect-protocol-enabled))
 
        flow-control-strategy-factory
@@ -202,10 +202,10 @@
        stream-idle-timeout
        (doto (.setStreamIdleTimeout stream-idle-timeout))
 
-       use-input-direct-byte-buffers
+       (boolean? use-input-direct-byte-buffers)
        (doto (.setUseInputDirectByteBuffers use-input-direct-byte-buffers))
 
-       use-output-direct-byte-buffers
+       (boolean? use-output-direct-byte-buffers)
        (doto (.setUseOutputDirectByteBuffers use-output-direct-byte-buffers))))))
 
 (defn- https-connector [server http-configuration ssl-context-factory h2? h2-options port host max-idle-time]
@@ -233,6 +233,8 @@
       (.setPort port)
       (.setHost host)
       (.setIdleTimeout max-idle-time))))
+
+(boolean? true)
 
 (defn- http3-connector [& args]
   ;; load http3 module dynamically


### PR DESCRIPTION
Add configuration for http2 connection factory.
As a map under :h2-options key in top level run-jetty config.

At the moment all options from [AbstractHTTP2ServerConnectionFactory](https://www.eclipse.org/jetty/javadoc/jetty-11/org/eclipse/jetty/http2/server/AbstractHTTP2ServerConnectionFactory.html), cause not sure which specific could be useful for an audience. Maybe it makes sense to keep only some of them.

Two of the options take java Objects as arg (FlowControlStrategy$Factory and RateControl$Factory), don't think it's worth to make wrappers.

Default values for options are leaved to Jetty.

Didn't tested yet, let's discuss general form and list of options for now.