### PR TITLE
feat: Implement jetty-core based websocket api for jetty 12

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,8 +21,9 @@
         #_ring.adapter.jetty9.handlers.async]
   :profiles {:dev {:dependencies [[clj-http "3.12.3"]
                                   [less-awful-ssl "1.0.6"]
-                                  #_[org.slf4j/slf4j-simple "2.0.0-alpha6"]
-                                  #_[stylefruits/gniazdo "1.1.4"]]}
+                                  [org.eclipse.jetty/jetty-slf4j-impl ~jetty-version]
+                                  #_[stylefruits/gniazdo "1.1.4"]]
+                   :resource-paths ["dev-resources"]}
              :example-http2 {:source-paths ["examples/"]
                              :main ^:skip-aot rj9a.http2}
              :example-http3 {:source-paths ["examples/"]

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -2,10 +2,11 @@
   "Adapter for the Jetty 10 server, with websocket support.
   Derived from ring.adapter.jetty"
   (:import [org.eclipse.jetty.server
-            Server Request ServerConnector Connector
+            Server Request ServerConnector Connector Handler
             HttpConfiguration HttpConnectionFactory
             ConnectionFactory SecureRequestCustomizer
             ProxyConnectionFactory]
+           [org.eclipse.jetty.server.handler ContextHandler]
            [org.eclipse.jetty.util.component AbstractLifeCycle]
            [org.eclipse.jetty.util.resource URLResourceFactory]
            [org.eclipse.jetty.util.thread
@@ -21,17 +22,17 @@
   (:require
     [clojure.string :as string]
     [ring.adapter.jetty9.common :as common]
-    #_[ring.adapter.jetty9.websocket :as ws]))
+    [ring.adapter.jetty9.websocket :as ws]))
 
-;; (def send! ws/send!)
-;; (def ping! ws/ping!)
-;; (def close! ws/close!)
-;; (def remote-addr ws/remote-addr)
-;; (def idle-timeout! ws/idle-timeout!)
-;; (def connected? ws/connected?)
-;; (def req-of ws/req-of)
-;; (def ws-upgrade-request? ws/ws-upgrade-request?)
-;; (def ws-upgrade-response ws/ws-upgrade-response)
+(def send! ws/send!)
+(def ping! ws/ping!)
+(def close! ws/close!)
+(def remote-addr ws/remote-addr)
+(def idle-timeout! ws/idle-timeout!)
+(def connected? ws/connected?)
+(def req-of ws/req-of)
+(def ws-upgrade-request? ws/ws-upgrade-request?)
+(def ws-upgrade-response ws/ws-upgrade-response)
 
 (defn ^:internal proxy-handler
   "Returns a Jetty Handler implementation for the given Ring handler."
@@ -154,10 +155,10 @@
        (doto (.setMaxConcurrentStreams max-concurrent-streams))
 
        (option-provided? :max-dynamic-table-size)
-       (doto (.setMaxDynamicTableSize max-dynamic-table-size))
+       (doto (.setMaxDecoderTableCapacity max-dynamic-table-size))
 
        (option-provided? :max-frame-length)
-       (doto (.setMaxFrameLength max-frame-length))
+       (doto (.setMaxFrameSize max-frame-length))
 
        (option-provided? :max-header-block-fragment)
        (doto (.setMaxHeaderBlockFragment max-header-block-fragment))
@@ -322,10 +323,13 @@
                  join? true
                  wrap-jetty-handler identity}}]
   (let [^Server s (create-server options)
+        context-handler (ContextHandler. "/")
         ring-app-handler (if async?
                            (proxy-async-handler handler options)
                            (proxy-handler handler options))]
-    (.setHandler s ring-app-handler)
+    (.setHandler context-handler ^Handler ring-app-handler)
+    (.setHandler s ^Handler context-handler)
+    (ws/ensure-container s context-handler)
     (when-let [c configurator]
       (c s))
     (.start s)

--- a/src/ring/adapter/jetty9/handlers/sync.clj
+++ b/src/ring/adapter/jetty9/handlers/sync.clj
@@ -31,8 +31,9 @@
                            common/normalize-response)]
       (if-let [ws (common/websocket-upgrade-response? response-map)]
         (ws/upgrade-websocket request response callback ws options)
-        (common/update-response response response-map)))
+        (do
+          (common/update-response response response-map)
+          true)))
     (catch Throwable e
-      (Response/writeError request response callback e))
-    (finally
+      (Response/writeError request response callback e)
       true)))

--- a/src/ring/adapter/jetty9/handlers/sync.clj
+++ b/src/ring/adapter/jetty9/handlers/sync.clj
@@ -1,7 +1,7 @@
 (ns ring.adapter.jetty9.handlers.sync
   (:require
     [ring.adapter.jetty9.common :as common]
-    #_[ring.adapter.jetty9.websocket :as ws])
+    [ring.adapter.jetty9.websocket :as ws])
   (:import [org.eclipse.jetty.server Request Response]
            [org.eclipse.jetty.util Callback])
   (:gen-class
@@ -29,9 +29,8 @@
                            common/build-request-map
                            handler
                            common/normalize-response)]
-      (common/update-response response response-map)
-      #_(if-let [ws (common/websocket-upgrade-response? response-map)]
-        (ws/upgrade-websocket request response ws options)
+      (if-let [ws (common/websocket-upgrade-response? response-map)]
+        (ws/upgrade-websocket request response callback ws options)
         (common/update-response response response-map)))
     (catch Throwable e
       (Response/writeError request response callback e))

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -1,9 +1,9 @@
 (ns ring.adapter.jetty9.websocket
   (:import [org.eclipse.jetty.server Request Response Server]
            [org.eclipse.jetty.server.handler ContextHandler]
-           [org.eclipse.jetty.websocket.api Session Session$Listener Callback]
+           [org.eclipse.jetty.websocket.api Session Session$Listener$AutoDemanding Callback]
            [org.eclipse.jetty.websocket.server ServerWebSocketContainer
-            WebSocketCreator ServerUpgradeRequest]
+            WebSocketCreator ServerUpgradeRequest WebSocketUpgradeHandler]
            [org.eclipse.jetty.websocket.common JettyExtensionConfig]
            [clojure.lang IFn]
            [java.nio ByteBuffer]
@@ -127,16 +127,14 @@
          on-ping noop
          on-pong noop}}]
   (let [session (atom nil)]
-    (reify Session$Listener
+    (reify Session$Listener$AutoDemanding
       (^void onWebSocketOpen [this ^Session current-session]
-       (println "opened")
        (on-connect current-session)
        ;; save session
        (reset! session current-session))
       (^void onWebSocketError [this ^Throwable e]
        (on-error @session e))
       (^void onWebSocketText [this ^String message]
-       (println @session message)
        (on-text @session message))
       (^void onWebSocketClose [this ^int status ^String reason]
        (on-close @session status reason))

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -126,24 +126,26 @@
          on-bytes noop
          on-ping noop
          on-pong noop}}]
-  ;; TODO: save session
-  (reify Session$Listener
-    (^void onWebSocketOpen [this ^Session session]
-     (println "Open")
-     (on-connect this))
-    (^void onWebSocketError [this ^Throwable e]
-     (on-error this e))
-    (^void onWebSocketText [this ^String message]
-     (println message)
-     (on-text this message))
-    (^void onWebSocketClose [this ^int status ^String reason]
-     (on-close this status reason))
-    (^void onWebSocketBinary [this ^ByteBuffer payload ^Callback cb]
-     (on-bytes this payload))
-    (^void onWebSocketPing [this ^ByteBuffer bytebuffer]
-     (on-ping this bytebuffer))
-    (^void onWebSocketPong [this ^ByteBuffer bytebuffer]
-     (on-pong this bytebuffer))))
+  (let [session (atom nil)]
+    (reify Session$Listener
+      (^void onWebSocketOpen [this ^Session current-session]
+       (println "opened")
+       (on-connect current-session)
+       ;; save session
+       (reset! session current-session))
+      (^void onWebSocketError [this ^Throwable e]
+       (on-error @session e))
+      (^void onWebSocketText [this ^String message]
+       (println @session message)
+       (on-text @session message))
+      (^void onWebSocketClose [this ^int status ^String reason]
+       (on-close @session status reason))
+      (^void onWebSocketBinary [this ^ByteBuffer payload ^Callback cb]
+       (on-bytes @session payload))
+      (^void onWebSocketPing [this ^ByteBuffer bytebuffer]
+       (on-ping @session bytebuffer))
+      (^void onWebSocketPong [this ^ByteBuffer bytebuffer]
+       (on-pong @session bytebuffer)))))
 
 (defn reify-default-ws-creator
   [ws-fns]


### PR DESCRIPTION
This patch is to add back websocket api fully based on jetty-core of jetty 12