### PR TITLE
feat: port aysnc ring handler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
   :global-vars {*warn-on-reflection* true}
   :jvm-args ["-Xmx128m"]
   :aot [ring.adapter.jetty9.handlers.sync
-        #_ring.adapter.jetty9.handlers.async]
+        ring.adapter.jetty9.handlers.async]
   :profiles {:dev {:dependencies [[clj-http "3.12.3"]
                                   [less-awful-ssl "1.0.6"]
                                   #_[org.slf4j/slf4j-simple "2.0.0-alpha6"]

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -17,7 +17,7 @@
            [org.eclipse.jetty.http2 RateControl$Factory]
            [org.eclipse.jetty.alpn.server ALPNServerConnectionFactory]
            [java.security KeyStore]
-           [ring.adapter.jetty9.handlers SyncProxyHandler #_AsyncProxyHandler])
+           [ring.adapter.jetty9.handlers SyncProxyHandler AsyncProxyHandler])
   (:require
     [clojure.string :as string]
     [ring.adapter.jetty9.common :as common]
@@ -41,7 +41,7 @@
 (defn ^:internal proxy-async-handler
   "Returns a Jetty Handler implementation for the given Ring **async** handler."
   [handler options]
-  #_(AsyncProxyHandler. handler options))
+  (AsyncProxyHandler. handler options))
 
 (defn- http-config
   "Creates jetty http configurator"


### PR DESCRIPTION
This patch enables async ring handlers on jetty 12.

We still have a TODO here is for lack of `async-timeout` support on pure jetty APIs. If we really want to port that functionality, we will need to maintain a scheduler by ourself and schedule a task to track it.