### PR TITLE
fix: character encoding was previously returning content-type

### DIFF
--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -41,10 +41,12 @@
   ;; need to upgrade to websockets protocol.
   (and status (== 101 status) ws))
 
+
 (defn get-charset [^Request request]
   (when-let [content-type (.. request getHeaders (get HttpHeader/CONTENT_TYPE))]
     (or (when-let [^MimeTypes$Type mime (.get MimeTypes/CACHE content-type)]
-          (str (.getCharset mime)))
+          (when-let [charset (.getCharset mime)]
+            (str charset)))
         (MimeTypes/getCharsetFromContentType content-type))))
 
 (defn- get-client-cert [^Request request]

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -1,6 +1,6 @@
 (ns ring.adapter.jetty9.common
   (:require [ring.core.protocols :as protocols])
-  (:import [org.eclipse.jetty.http HttpHeader HttpField MimeTypes]
+  (:import [org.eclipse.jetty.http HttpHeader HttpField MimeTypes MimeTypes$Type]
            [org.eclipse.jetty.server.handler BufferedResponseHandler]
            [org.eclipse.jetty.server Request Response SecureRequestCustomizer]
            [org.eclipse.jetty.io Content$Sink]
@@ -43,9 +43,9 @@
 
 (defn get-charset [^Request request]
   (when-let [content-type (.. request getHeaders (get HttpHeader/CONTENT_TYPE))]
-    (if-let [mime-type-charset (.get MimeTypes/CACHE content-type)]
-      (str mime-type-charset)
-      (MimeTypes/getCharsetFromContentType content-type))))
+    (or (when-let [^MimeTypes$Type mime (.get MimeTypes/CACHE content-type)]
+          (str (.getCharset mime)))
+        (MimeTypes/getCharsetFromContentType content-type))))
 
 (defn- get-client-cert [^Request request]
   (.getAttribute request SecureRequestCustomizer/PEER_CERTIFICATES_ATTRIBUTE))


### PR DESCRIPTION
<img width="1146" alt="image" src="https://github.com/sunng87/ring-jetty9-adapter/assets/550839/e0b3a8fa-194b-4ee7-8b05-abe902217d96">

when looking at request maps, found a bug with character encoding 