### PR TITLE
feat: upgrade jetty to 12.0.2 and improve buffered output stream

### DIFF
--- a/http3/project.clj
+++ b/http3/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "12.0.1")
+(def jetty-version "12.0.2")
 
 (defproject info.sunng/ring-jetty9-adapter-http3 "0.4.0"
   :description "Ring adapter for jetty 9 and above, meta package for http3"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "12.0.1")
+(def jetty-version "12.0.2")
 
 (defproject info.sunng/ring-jetty9-adapter "0.30.1-SNAPSHOT"
   :description "Ring adapter for jetty9, which supports websocket and spdy"

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -77,7 +77,7 @@
 
 (defn update-response
   "Update Jetty Response from given Ring response map"
-  [^Response response response-map]
+  [^Request request ^Response response response-map]
   (let [{:keys [status headers body]} response-map]
     (cond
       (nil? response)     (throw (NullPointerException. "Response is nil"))
@@ -87,8 +87,5 @@
         (some->> status (.setStatus response))
         (set-headers! response headers)
         (->>
-          (Content$Sink/asOutputStream response)
+          (Response/asBufferedOutputStream request response)
           (protocols/write-body-to-stream body response-map))))))
-
-(defn ensure-response-buffer-size! [^Request request]
-  (.setAttribute request BufferedResponseHandler/BUFFER_SIZE_ATTRIBUTE_NAME 16384))

--- a/src/ring/adapter/jetty9/handlers/async.clj
+++ b/src/ring/adapter/jetty9/handlers/async.clj
@@ -23,7 +23,6 @@
    ^Request request
    ^Response response
    ^Callback callback]
-  (common/ensure-response-buffer-size! request)
   (try
     (let [[handler options] (.state this)
           ;;TODO: async timeout
@@ -35,7 +34,7 @@
           (let [response-map (common/normalize-response response-map)]
             (if-let [ws (common/websocket-upgrade-response? response-map)]
               (ws/upgrade-websocket request response callback ws)
-              (common/update-response response response-map)))
+              (common/update-response request response response-map)))
           (.succeeded callback))
         (fn [^Throwable exception]
           (Response/writeError request response callback exception)

--- a/src/ring/adapter/jetty9/handlers/sync.clj
+++ b/src/ring/adapter/jetty9/handlers/sync.clj
@@ -23,7 +23,6 @@
    ^Request request
    ^Response response
    ^Callback callback]
-  (common/ensure-response-buffer-size! request)
   (try
     (let [[handler options] (.state this)
           response-map (-> request
@@ -33,7 +32,7 @@
       (if-let [ws (common/websocket-upgrade-response? response-map)]
         (ws/upgrade-websocket request response callback ws options)
         (do
-          (common/update-response response response-map)
+          (common/update-response request response response-map)
           (.succeeded callback)
           true)))
     (catch Throwable e


### PR DESCRIPTION
This patch upgrades Jetty to 12.0.2 and bring in improvements on Buffer outputstream in https://github.com/eclipse/jetty.project/issues/10476