### PR TITLE
debug logging of internal exception in case response can not be sent to client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
                  [org.eclipse.jetty.websocket/websocket-servlet ~jetty-version]
                  [org.eclipse.jetty.http2/http2-server ~jetty-version]
                  [org.eclipse.jetty/jetty-alpn-server ~jetty-version]
-                 [org.eclipse.jetty/jetty-alpn-java-server ~jetty-version]]
+                 [org.eclipse.jetty/jetty-alpn-java-server ~jetty-version]
+                 [org.clojure/tools.logging "1.2.3"]]
   :deploy-repositories {"releases" :clojars}
   :global-vars {*warn-on-reflection* true}
   :jvm-args ["-Xmx128m"]

--- a/src/ring/adapter/jetty9/handlers/sync.clj
+++ b/src/ring/adapter/jetty9/handlers/sync.clj
@@ -2,7 +2,8 @@
   (:require
     [ring.adapter.jetty9.common :as common]
     [ring.adapter.jetty9.servlet :as servlet]
-    [ring.adapter.jetty9.websocket :as ws])
+    [ring.adapter.jetty9.websocket :as ws]
+    [clojure.tools.logging :as log])
   (:import [jakarta.servlet.http HttpServletRequest HttpServletResponse]
            [org.eclipse.jetty.server Request])
   (:gen-class
@@ -35,6 +36,7 @@
         (ws/upgrade-websocket request response ws options)
         (servlet/update-servlet-response response response-map)))
     (catch Throwable e
+      (log/debug e)
       (.sendError response 500 (.getMessage e)))
     (finally
       (.setHandled base-request true))))


### PR DESCRIPTION
It provides information about original eception in case when response channel was already closed ( we just had it in http2 communication)

In this scenario message from original exception is lost because jetty in sendError throws new IllegalStateException whenever output channel is not open.