### PR TITLE
Add `ws-configurator` parameter

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -306,6 +306,7 @@
   :max-idle-time  - the maximum idle time in milliseconds for a connection (default 200000)
   :output-buffer-size - size of http response buffer, default to 32768
   :output-aggregation-size - size of http aggregation size, defualt to 8192
+  :ws-configurator - a function called with the websocket container instance (allows for configuration beyond the supported options listed below)
   :ws-max-idle-time  - the maximum idle time in milliseconds for a websocket connection (default 500000)
   :ws-max-text-message-size  - the maximum text message size in bytes for a websocket connection (default 65536)
   :client-auth - SSL client certificate authenticate, may be set to :need, :want or :none (defaults to :none)

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -87,14 +87,17 @@
    ws-resp
    {:as _options
     :keys [ws-max-idle-time
-           ws-max-text-message-size]
+           ws-max-text-message-size
+           ws-configurator]
     :or {ws-max-idle-time 500000
-         ws-max-text-message-size 65536}}]
+         ws-max-text-message-size 65536
+         ws-configurator (constantly nil)}}]
   {:pre [(map? ws-resp)]}
   (let [container (ServerWebSocketContainer/get (.getContext req))
         creator (reify-ws-creator ws-resp)]
     (.setIdleTimeout container (Duration/ofMillis ws-max-idle-time))
     (.setMaxTextMessageSize container ws-max-text-message-size)
+    (ws-configurator container)
     (.upgrade container creator req resp cb)))
 
 (defn ws-upgrade-request?


### PR DESCRIPTION
For adding arbitrary config to the websocket container object.