### PR TITLE
feat: add more options for websocket

### DIFF
--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -307,8 +307,10 @@
   :output-buffer-size - size of http response buffer, default to 32768
   :output-aggregation-size - size of http aggregation size, defualt to 8192
   :ws-configurator - a function called with the websocket container instance (allows for configuration beyond the supported options listed below)
-  :ws-max-idle-time  - the maximum idle time in milliseconds for a websocket connection (default 500000)
-  :ws-max-text-message-size  - the maximum text message size in bytes for a websocket connection (default 65536)
+  :ws-max-idle-time - the maximum idle time in milliseconds for a websocket connection (default 30000, inherited from jetty defaults)
+  :ws-max-frame-size - the maximum message size in bytes for a websocket connection (default 65536, inherited from jetty defaults)
+  :ws-max-binary-message-size - the maximum binary message size in bytes for a websocket connection (default 65536, inherited from jetty defaults)
+  :ws-max-text-message-size  - the maximum text message size in bytes for a websocket connection (default 65536, inherited from jetty defaults)
   :client-auth - SSL client certificate authenticate, may be set to :need, :want or :none (defaults to :none)
   :h2? - enable http2 protocol on secure socket port
   :h2c? - enable http2 clear text on plain socket port

--- a/src/ring/adapter/jetty9/websocket.clj
+++ b/src/ring/adapter/jetty9/websocket.clj
@@ -87,16 +87,22 @@
    ws-resp
    {:as _options
     :keys [ws-max-idle-time
+           ws-max-frame-size
+           ws-max-binary-message-size
            ws-max-text-message-size
            ws-configurator]
-    :or {ws-max-idle-time 500000
-         ws-max-text-message-size 65536
-         ws-configurator (constantly nil)}}]
+    :or {ws-configurator (constantly nil)}}]
   {:pre [(map? ws-resp)]}
   (let [container (ServerWebSocketContainer/get (.getContext req))
         creator (reify-ws-creator ws-resp)]
-    (.setIdleTimeout container (Duration/ofMillis ws-max-idle-time))
-    (.setMaxTextMessageSize container ws-max-text-message-size)
+    (when ws-max-idle-time
+      (.setIdleTimeout container (Duration/ofMillis ws-max-idle-time)))
+    (when ws-max-frame-size
+      (.setMaxFrameSize container ws-max-frame-size))
+    (when ws-max-binary-message-size
+      (.setMaxBinaryMessageSize container ws-max-binary-message-size))
+    (when ws-max-text-message-size
+      (.setMaxTextMessageSize container ws-max-text-message-size))
     (ws-configurator container)
     (.upgrade container creator req resp cb)))
 


### PR DESCRIPTION
Fixes #124 

Added options to configure max frame size and max binary message size. Note that this patch also changed default value of `ws-max-idle-time` to default value of jetty: 30s.