### PR TITLE
fix: allows async StreamableResponseBody

### DIFF
--- a/examples/rj9a/http.clj
+++ b/examples/rj9a/http.clj
@@ -1,10 +1,25 @@
 (ns rj9a.http
   (:gen-class)
-  (:require [ring.adapter.jetty9 :as jetty]))
+  (:require [ring.adapter.jetty9 :as jetty]
+            [clojure.java.io :as io]))
 
 (defn dummy-app [req]
   (println req)
   {:body "It works" :status 200})
+
+(comment
+  (defn dummy-app [req]
+    {:status 200
+     :body (reify
+             ring.core.protocols/StreamableResponseBody
+             (write-body-to-stream [_ _ output-stream]
+               (let [writer (io/writer output-stream)]
+                 (future (loop [i 10]
+                           (doto writer (.write (str "data: " i "\n")) .flush)
+                           (if (zero? i)
+                             (.close writer)
+                             (do (Thread/sleep 100)
+                                 (recur (dec i)))))))))}))
 
 (defn -main [& args]
   (jetty/run-jetty dummy-app {:port 5000}))

--- a/src/ring/adapter/jetty9/handlers/sync.clj
+++ b/src/ring/adapter/jetty9/handlers/sync.clj
@@ -1,17 +1,17 @@
 (ns ring.adapter.jetty9.handlers.sync
   (:require
-    [ring.adapter.jetty9.common :as common]
-    [ring.adapter.jetty9.websocket :as ws])
+   [ring.adapter.jetty9.common :as common]
+   [ring.adapter.jetty9.websocket :as ws])
   (:import [org.eclipse.jetty.server Request Response]
            [org.eclipse.jetty.util Callback])
   (:gen-class
-    :name ring.adapter.jetty9.handlers.SyncProxyHandler
-    :extends org.eclipse.jetty.server.Handler$Abstract
-    :state state
-    :init init
-    :constructors {[clojure.lang.IFn
-                    clojure.lang.IPersistentMap] []}
-    :prefix "-"))
+   :name ring.adapter.jetty9.handlers.SyncProxyHandler
+   :extends org.eclipse.jetty.server.Handler$Abstract
+   :state state
+   :init init
+   :constructors {[clojure.lang.IFn
+                   clojure.lang.IPersistentMap] []}
+   :prefix "-"))
 
 (defn -init
   [ring-handler opts]
@@ -33,7 +33,9 @@
         (ws/upgrade-websocket request response callback response-map options)
         (do
           (common/update-response request response response-map)
-          (.succeeded callback)
+          (when-not (satisfies? ring.core.protocols/StreamableResponseBody
+                                (:body response-map))
+            (.succeeded callback))
           true)))
     (catch Throwable e
       (Response/writeError request response callback e)


### PR DESCRIPTION
Fixes #122 

Skip resolving callback for `StreamableResponseBody`. But I still need to investigate the impact of not resolving it.