### PR TITLE
feat: upgarde http3 module to latest QuicServerConnector api

### DIFF
--- a/http3/project.clj
+++ b/http3/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "12.0.7")
 
-(defproject info.sunng/ring-jetty9-adapter-http3 "0.4.6"
+(defproject info.sunng/ring-jetty9-adapter-http3 "0.5.0-SNAPSHOT"
   :description "Ring adapter for jetty 9 and above, meta package for http3"
   :url "http://github.com/sunng87/ring-jetty9-adapter"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [ring/ring-core "1.11.0" :exclusions [commons-io]]
                  [org.ring-clojure/ring-websocket-protocols "1.11.0"]
-                 [info.sunng/ring-jetty9-adapter-http3 "0.4.6" :optional true]
+                 [info.sunng/ring-jetty9-adapter-http3 "0.5.0-SNAPSHOT" :optional true]
                  [org.eclipse.jetty/jetty-server ~jetty-version]
                  [org.eclipse.jetty/jetty-util ~jetty-version]
                  [org.eclipse.jetty.websocket/jetty-websocket-jetty-api ~jetty-version]

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -201,10 +201,10 @@
       (.setHost host)
       (.setIdleTimeout max-idle-time))))
 
-(defn- http3-connector [& args]
+(defn- quic-server-connector [& args]
   ;; load http3 module dynamically
-  (let [http3-connector* @(requiring-resolve 'ring.adapter.jetty9.http3/http3-connector)]
-    (apply http3-connector* args)))
+  (let [quic-server-connector* @(requiring-resolve 'ring.adapter.jetty9.http3/quic-server-connector)]
+    (apply quic-server-connector* args)))
 
 (defn- create-server
   "Construct a Jetty Server instance."
@@ -249,9 +249,9 @@
                      ssl?  (conj (https-connector server http-configuration @ssl-factory
                                                   h2? h2-options ssl-port host max-idle-time))
                      http? (conj (http-connector server http-configuration h2c? h2-options port host max-idle-time proxy?))
-                     http3? (conj (http3-connector server http-configuration
-                                                   (assoc http3-options :pem-work-directory http3-pem-work-directory)
-                                                   @ssl-factory ssl-port host)))]
+                     http3? (conj (quic-server-connector server http3-options
+                                                         @ssl-factory http3-pem-work-directory
+                                                         ssl-port host)))]
     (when (and ssl?
                (not (false? ssl-hot-reload?))
                (some? (.getKeyStorePath ^SslContextFactory @ssl-factory)))

--- a/test/ring/adapter/jetty9_test.clj
+++ b/test/ring/adapter/jetty9_test.clj
@@ -293,7 +293,7 @@
          :use-input-direct-byte-buffers false
          :use-output-direct-byte-buffers false}]
     (.mkdirs (clojure.java.io/file pem-work-dir))
-    (with-jetty [server [dummy-app {:ssl-port        50524
+    (with-jetty [server [dummy-app {:ssl-port        50525
                                     :port            50523
                                     :ssl?            true
                                     :join?           false


### PR DESCRIPTION
The original `Http3ServerConnector` has been deprecated. This patch upgrades `http3` module to latest api. The user-facing api of rj9a remains unchanged.