### PR TITLE
feat: support http2 request headers that contains multiple cookie fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pom.xml.asc
 .idea/
 *.iml
 /.nrepl-port
+/.clj-kondo
+/.lsp

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -21,10 +21,22 @@
   [^HttpField header]
   [(.getLowerCaseName header) (.getValue header)])
 
+(defn- combine-headers
+  ([] {})
+  ([result] result)
+  ([result [k v]]
+   (if (and (= "cookie" k) (get result k))
+     (update result k #(str % "; " v))
+     (assoc result k v))))
+
 (defn get-headers
   "Creates a name/value map of all the request headers."
   [^Request request]
-  (into {} (map header-kv*) (.getHeaders request)))
+  (transduce
+   (map header-kv*)
+   combine-headers
+   {}
+   (.getHeaders request)))
 
 (defonce noop (constantly nil))
 


### PR DESCRIPTION
Fixes #136.

Changes the `get-headers` function to merge multiple cookie fields into one field; make the behavior consistent with HTTP/1.1 headers. Also added `.lsp` and `.clj-kondo` to gitignore. 