### PR TITLE
fix: remove auto error handle in async handler

### DIFF
--- a/src/ring/adapter/jetty9/handlers/async.clj
+++ b/src/ring/adapter/jetty9/handlers/async.clj
@@ -36,7 +36,6 @@
            (common/update-response request response response-map)))
        (.succeeded callback))
      (fn [^Throwable exception]
-       (Response/writeError request response callback exception)
        (.failed callback exception))))
 
   true)


### PR DESCRIPTION
Keep our error processing consistent.