### PR TITLE
feat: update http configuration 

### DIFF
--- a/http3/src/ring/adapter/jetty9/http3.clj
+++ b/http3/src/ring/adapter/jetty9/http3.clj
@@ -9,7 +9,8 @@
 (defmacro cond->-config-options [configuration options config-items]
   `(cond-> ~configuration
      ~@(mapcat (fn [item]
-                 (let [camel-case-item (clojure.string/replace (name item) #"-." #(clojure.string/upper-case (subs % 1)))
+                 (let [item-name (clojure.string/replace (name item) #"\?$" "")
+                       camel-case-item (clojure.string/replace item-name #"-." #(clojure.string/upper-case (subs % 1)))
                        pascal-case-item (str (clojure.string/upper-case (subs camel-case-item 0 1)) (subs camel-case-item 1))]
                    [`(contains? ~options ~item)
                     `(doto (. ~(symbol (str "set" pascal-case-item)) (~item ~options)))]))
@@ -39,7 +40,7 @@
                             :bidirectional-max-streams :unidirectional-max-streams
 
                             :input-buffer-size :output-buffer-size
-                            :use-input-direct-byte-buffers :use-output-direct-byte-buffers
+                            :use-input-direct-byte-buffers? :use-output-direct-byte-buffers?
 
                             :stream-idle-timeout :min-input-buffer-space])
 

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -6,7 +6,6 @@
             HttpConfiguration HttpConnectionFactory
             ConnectionFactory SecureRequestCustomizer
             ProxyConnectionFactory]
-           [org.eclipse.jetty.http CookieCompliance UriCompliance HttpCompliance MultiPartCompliance]
            [org.eclipse.jetty.server.handler ContextHandler]
            [org.eclipse.jetty.util VirtualThreads]
            [org.eclipse.jetty.util.component AbstractLifeCycle]
@@ -18,7 +17,8 @@
            [ring.adapter.jetty9.handlers SyncProxyHandler AsyncProxyHandler])
   (:require
    [clojure.string :as string]
-   [ring.adapter.jetty9.websocket :as ws]))
+   [ring.adapter.jetty9.websocket :as ws]
+   [ring.adapter.jetty9.common :as common]))
 
 (def ws-upgrade-request? ws/ws-upgrade-request?)
 
@@ -34,118 +34,51 @@
 
 (defn- http-config
   "Creates jetty http configurator"
-  [{:as _
-    :keys [input-buffer-size
-           output-buffer-size
-           output-aggregation-size
-           request-header-size
-           response-header-size
-           max-response-header-size
-           header-cache-size
-           header-cache-case-sensitive?
-           secure-port
-           idle-timeout
-           secure-scheme
-           send-server-version?
-           send-x-powered-by?
-           send-date-header?
-           delay-dispatch-until-content?
-           persistent-connections-enabled?
-           max-error-dispatches
-           use-input-direct-byte-buffers?
-           use-output-direct-byte-buffers?
-           min-request-data-rate
-           min-response-data-rate
-           http-compliance
-           uri-compliance
-           redirect-uri-compliance
-           request-cookie-compliance
-           response-cookie-compliance
-           multi-part-compliance
-           notify-remote-async-errors?
-           relative-redirect-allowed?
-           generate-redirect-body?
-           server-authority
-           local-address
-           max-unconsumed-request-content-reads
-           min-input-buffer-space
-
-           sni-required? sni-host-check?]
-    :or {input-buffer-size 8192
-         output-buffer-size 32768
-         output-aggregation-size 8192
-         request-header-size 8192
-         response-header-size 8192
-         max-response-header-size 16384
-         header-cache-size 1024
-         header-cache-case-sensitive? false
-         secure-port 443
-         idle-timeout -1
-         secure-scheme "https"
-         send-server-version? true
-         send-x-powered-by? false
-         send-date-header? true
-         delay-dispatch-until-content? true
-         persistent-connections-enabled? true
-         max-error-dispatches 10
-         use-input-direct-byte-buffers? true
-         use-output-direct-byte-buffers? true
-         min-request-data-rate 0
-         min-response-data-rate 0
-         http-compliance HttpCompliance/RFC9110
-         uri-compliance UriCompliance/DEFAULT
-         redirect-uri-compliance UriCompliance/DEFAULT
-         request-cookie-compliance CookieCompliance/RFC6265
-         response-cookie-compliance CookieCompliance/RFC6265
-         multi-part-compliance MultiPartCompliance/RFC7578
-         notify-remote-async-errors? true
-         relative-redirect-allowed? true
-         generate-redirect-body? false
-         server-authority nil
-         local-address nil
-         max-unconsumed-request-content-reads 16
-         min-input-buffer-space 1500
-
-         sni-required? false
+  [{:as http-options
+    :keys [sni-required? sni-host-check?]
+    :or {sni-required? false
          sni-host-check? true}}]
   (let [secure-customizer (doto (SecureRequestCustomizer.)
                             (.setSniRequired sni-required?)
-                            (.setSniHostCheck sni-host-check?))]
-    (doto (HttpConfiguration.)
-      (.setInputBufferSize input-buffer-size)
-      (.setOutputBufferSize output-buffer-size)
-      (.setOutputAggregationSize output-aggregation-size)
-      (.setRequestHeaderSize request-header-size)
-      (.setResponseHeaderSize response-header-size)
-      (.setMaxResponseHeaderSize max-response-header-size)
-      (.setHeaderCacheSize header-cache-size)
-      (.setHeaderCacheCaseSensitive header-cache-case-sensitive?)
-      (.setSecurePort secure-port)
-      (.setIdleTimeout idle-timeout)
-      (.setSecureScheme secure-scheme)
-      (.setSendServerVersion send-server-version?)
-      (.setSendXPoweredBy send-x-powered-by?)
-      (.setSendDateHeader send-date-header?)
-      (.setDelayDispatchUntilContent delay-dispatch-until-content?)
-      (.setPersistentConnectionsEnabled persistent-connections-enabled?)
-      (.setMaxErrorDispatches max-error-dispatches)
-      (.setUseInputDirectByteBuffers use-input-direct-byte-buffers?)
-      (.setUseOutputDirectByteBuffers use-output-direct-byte-buffers?)
-      (.setMinRequestDataRate min-request-data-rate)
-      (.setMinResponseDataRate min-response-data-rate)
-      (.setHttpCompliance http-compliance)
-      (.setUriCompliance uri-compliance)
-      (.setRedirectUriCompliance redirect-uri-compliance)
-      (.setRequestCookieCompliance request-cookie-compliance)
-      (.setResponseCookieCompliance response-cookie-compliance)
-      (.setMultiPartCompliance multi-part-compliance)
-      (.setNotifyRemoteAsyncErrors notify-remote-async-errors?)
-      (.setRelativeRedirectAllowed relative-redirect-allowed?)
-      (.setGenerateRedirectBody generate-redirect-body?)
-      (.setServerAuthority server-authority)
-      (.setLocalAddress local-address)
-      (.setMaxUnconsumedRequestContentReads max-unconsumed-request-content-reads)
-      (.setMinInputBufferSpace min-input-buffer-space)
+                            (.setSniHostCheck sni-host-check?))
+        http-configuration (HttpConfiguration.)]
+
+    (common/cond->-config-options http-configuration http-options
+                                  [:input-buffer-size
+                                   :output-buffer-size
+                                   :output-aggregation-size
+                                   :request-header-size
+                                   :response-header-size
+                                   :max-response-header-size
+                                   :header-cache-size
+                                   :header-cache-case-sensitive?
+                                   :secure-port
+                                   :idle-timeout
+                                   :secure-scheme
+                                   :send-server-version?
+                                   :send-x-powered-by?
+                                   :send-date-header?
+                                   :delay-dispatch-until-content?
+                                   :persistent-connections-enabled?
+                                   :max-error-dispatches
+                                   :use-input-direct-byte-buffers?
+                                   :use-output-direct-byte-buffers?
+                                   :min-request-data-rate
+                                   :min-response-data-rate
+                                   :http-compliance
+                                   :uri-compliance
+                                   :redirect-uri-compliance
+                                   :request-cookie-compliance
+                                   :response-cookie-compliance
+                                   :multi-part-compliance
+                                   :notify-remote-async-errors?
+                                   :relative-redirect-allowed?
+                                   :generate-redirect-body?
+                                   :server-authority
+                                   :local-address
+                                   :max-unconsumed-request-content-reads
+                                   :min-input-buffer-space])
+    (doto http-configuration
       (.addCustomizer secure-customizer))))
 
 (defn- ssl-context-factory

--- a/src/ring/adapter/jetty9.clj
+++ b/src/ring/adapter/jetty9.clj
@@ -6,6 +6,7 @@
             HttpConfiguration HttpConnectionFactory
             ConnectionFactory SecureRequestCustomizer
             ProxyConnectionFactory]
+           [org.eclipse.jetty.http CookieCompliance UriCompliance HttpCompliance MultiPartCompliance]
            [org.eclipse.jetty.server.handler ContextHandler]
            [org.eclipse.jetty.util VirtualThreads]
            [org.eclipse.jetty.util.component AbstractLifeCycle]
@@ -34,35 +35,117 @@
 (defn- http-config
   "Creates jetty http configurator"
   [{:as _
-    :keys [ssl-port secure-scheme output-buffer-size output-aggregation-size
-           request-header-size response-header-size send-server-version? send-date-header?
-           header-cache-size sni-required? sni-host-check?]
-    :or {ssl-port 443
-         secure-scheme "https"
+    :keys [input-buffer-size
+           output-buffer-size
+           output-aggregation-size
+           request-header-size
+           response-header-size
+           max-response-header-size
+           header-cache-size
+           header-cache-case-sensitive?
+           secure-port
+           idle-timeout
+           secure-scheme
+           send-server-version?
+           send-x-powered-by?
+           send-date-header?
+           delay-dispatch-until-content?
+           persistent-connections-enabled?
+           max-error-dispatches
+           use-input-direct-byte-buffers?
+           use-output-direct-byte-buffers?
+           min-request-data-rate
+           min-response-data-rate
+           http-compliance
+           uri-compliance
+           redirect-uri-compliance
+           request-cookie-compliance
+           response-cookie-compliance
+           multi-part-compliance
+           notify-remote-async-errors?
+           relative-redirect-allowed?
+           generate-redirect-body?
+           server-authority
+           local-address
+           max-unconsumed-request-content-reads
+           min-input-buffer-space
+
+           sni-required? sni-host-check?]
+    :or {input-buffer-size 8192
          output-buffer-size 32768
          output-aggregation-size 8192
          request-header-size 8192
          response-header-size 8192
-         send-server-version? true
-         send-date-header? false
+         max-response-header-size 16384
          header-cache-size 1024
+         header-cache-case-sensitive? false
+         secure-port 443
+         idle-timeout -1
+         secure-scheme "https"
+         send-server-version? true
+         send-x-powered-by? false
+         send-date-header? true
+         delay-dispatch-until-content? true
+         persistent-connections-enabled? true
+         max-error-dispatches 10
+         use-input-direct-byte-buffers? true
+         use-output-direct-byte-buffers? true
+         min-request-data-rate 0
+         min-response-data-rate 0
+         http-compliance HttpCompliance/RFC9110
+         uri-compliance UriCompliance/DEFAULT
+         redirect-uri-compliance UriCompliance/DEFAULT
+         request-cookie-compliance CookieCompliance/RFC6265
+         response-cookie-compliance CookieCompliance/RFC6265
+         multi-part-compliance MultiPartCompliance/RFC7578
+         notify-remote-async-errors? true
+         relative-redirect-allowed? true
+         generate-redirect-body? false
+         server-authority nil
+         local-address nil
+         max-unconsumed-request-content-reads 16
+         min-input-buffer-space 1500
+
          sni-required? false
          sni-host-check? true}}]
   (let [secure-customizer (doto (SecureRequestCustomizer.)
                             (.setSniRequired sni-required?)
                             (.setSniHostCheck sni-host-check?))]
     (doto (HttpConfiguration.)
-      (.setSecureScheme secure-scheme)
-      (.setSecurePort ssl-port)
+      (.setInputBufferSize input-buffer-size)
       (.setOutputBufferSize output-buffer-size)
       (.setOutputAggregationSize output-aggregation-size)
       (.setRequestHeaderSize request-header-size)
       (.setResponseHeaderSize response-header-size)
-      (.setSendServerVersion send-server-version?)
-      (.setSendDateHeader send-date-header?)
+      (.setMaxResponseHeaderSize max-response-header-size)
       (.setHeaderCacheSize header-cache-size)
-      ;; duplicated with http configuration :max-idle-time
-      #_(.setIdleTimeout idle-timeout-ms)
+      (.setHeaderCacheCaseSensitive header-cache-case-sensitive?)
+      (.setSecurePort secure-port)
+      (.setIdleTimeout idle-timeout)
+      (.setSecureScheme secure-scheme)
+      (.setSendServerVersion send-server-version?)
+      (.setSendXPoweredBy send-x-powered-by?)
+      (.setSendDateHeader send-date-header?)
+      (.setDelayDispatchUntilContent delay-dispatch-until-content?)
+      (.setPersistentConnectionsEnabled persistent-connections-enabled?)
+      (.setMaxErrorDispatches max-error-dispatches)
+      (.setUseInputDirectByteBuffers use-input-direct-byte-buffers?)
+      (.setUseOutputDirectByteBuffers use-output-direct-byte-buffers?)
+      (.setMinRequestDataRate min-request-data-rate)
+      (.setMinResponseDataRate min-response-data-rate)
+      (.setHttpCompliance http-compliance)
+      (.setUriCompliance uri-compliance)
+      (.setRedirectUriCompliance redirect-uri-compliance)
+      (.setRequestCookieCompliance request-cookie-compliance)
+      (.setResponseCookieCompliance response-cookie-compliance)
+      (.setMultiPartCompliance multi-part-compliance)
+      (.setNotifyRemoteAsyncErrors notify-remote-async-errors?)
+      (.setRelativeRedirectAllowed relative-redirect-allowed?)
+      (.setGenerateRedirectBody generate-redirect-body?)
+      (.setServerAuthority server-authority)
+      (.setLocalAddress local-address)
+      (.setMaxUnconsumedRequestContentReads max-unconsumed-request-content-reads)
+      (.setMinInputBufferSpace min-input-buffer-space)
       (.addCustomizer secure-customizer))))
 
 (defn- ssl-context-factory
@@ -274,10 +357,7 @@
   :sni-host-check? - enable host check for secure connection, default to true
   :http3? - enable http3 protocol, make sure you have `info.sunng/ring-jetty9-adapter-http3` package on classpath
   :http3-pem-work-directory - required when http3 enabled, specify a directory as http3 pem work dir
-  :http3-options - map with options specific for http3
-                  (all setters from https://www.eclipse.org/jetty/javadoc/jetty-11/org/eclipse/jetty/http3/HTTP3Configuration.html
-                   and https://www.eclipse.org/jetty/javadoc/jetty-11/org/eclipse/jetty/quic/common/QuicConfiguration.html,
-                   kebab cased without \"set\", e.g. setStreamIdleTimeout -> stream-idle-timeout)"
+  :http3-options - map with options specific for http3/quic, all properties are following org.eclipse.jetty.quic.common.QuicConfiguration"
   [handler {:as options
             :keys [configurator join? async?
                    wrap-jetty-handler]

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -1,5 +1,6 @@
 (ns ring.adapter.jetty9.common
-  (:require [ring.core.protocols :as protocols])
+  (:require [ring.core.protocols :as protocols]
+            [clojure.string])
   (:import [org.eclipse.jetty.http HttpHeader HttpField MimeTypes MimeTypes$Type]
            [org.eclipse.jetty.server Request Response]
            [org.eclipse.jetty.io EndPoint$SslSessionData]

--- a/src/ring/adapter/jetty9/common.clj
+++ b/src/ring/adapter/jetty9/common.clj
@@ -98,3 +98,13 @@
         (->>
          (Response/asBufferedOutputStream request response)
          (protocols/write-body-to-stream body response-map))))))
+
+(defmacro cond->-config-options [configuration options config-items]
+  `(cond-> ~configuration
+     ~@(mapcat (fn [item]
+                 (let [item-name (clojure.string/replace (name item) #"\?$" "")
+                       camel-case-item (clojure.string/replace item-name #"-." #(clojure.string/upper-case (subs % 1)))
+                       pascal-case-item (str (clojure.string/upper-case (subs camel-case-item 0 1)) (subs camel-case-item 1))]
+                   [`(contains? ~options ~item)
+                    `(doto (. ~(symbol (str "set" pascal-case-item)) (~item ~options)))]))
+               config-items)))


### PR DESCRIPTION
Fixes #161 

This patch included all http configuration items from latest jetty release. It also refactors how we implement the configuration generation. We no longer provide default values in our codebase.