### PR TITLE
feat: run async handlers on jetty worker thread pool

### DIFF
--- a/src/ring/adapter/jetty9/handlers/async.clj
+++ b/src/ring/adapter/jetty9/handlers/async.clj
@@ -27,15 +27,22 @@
         ;;TODO: async timeout
         ;; async-timeout (:async-timeout options 30000)
         ]
-    (handler
-     (common/build-request-map request)
-     (fn [response-map]
-       (let [response-map (common/normalize-response response-map)]
-         (if (common/websocket-upgrade-response? response-map)
-           (ws/upgrade-websocket request response callback response-map options)
-           (common/update-response request response response-map)))
-       (.succeeded callback))
-     (fn [^Throwable exception]
-       (.failed callback exception))))
-
-  true)
+    ;; Dispatch the async handler on the server's thread pool (mirrors
+    ;; Jetty's `AsyncContext.start` / `Context.execute` semantics) so that
+    ;; we never block the connector dispatch thread, which is especially
+    ;; important for HTTP/2 and HTTP/3 where a single thread multiplexes
+    ;; many streams.
+    (.execute (.getContext request)
+              ^Runnable
+              (fn []
+                (handler
+                 (common/build-request-map request)
+                 (fn [response-map]
+                   (let [response-map (common/normalize-response response-map)]
+                     (if (common/websocket-upgrade-response? response-map)
+                       (ws/upgrade-websocket request response callback response-map options)
+                       (common/update-response request response response-map)))
+                   (.succeeded callback))
+                 (fn [^Throwable exception]
+                   (.failed callback exception)))))
+    true))

--- a/test/ring/adapter/jetty9_test.clj
+++ b/test/ring/adapter/jetty9_test.clj
@@ -74,6 +74,32 @@
       (is (= 200 (:status resp)))
       (is (= "yes" (:body resp))))))
 
+(deftest jetty9-async-handler-test
+  (let [handler-thread-name (atom nil)]
+    (with-jetty [server [(fn [req respond raise]
+                           ;; capture the thread the handler runs on so we
+                           ;; can assert it was dispatched onto a Jetty
+                           ;; QueuedThreadPool worker thread, rather than
+                           ;; running inline on the selector/acceptor thread
+                           ;; (see issue #170)
+                           (reset! handler-thread-name (.getName (Thread/currentThread)))
+                           (respond {:status 200 :body "async-yes"}))
+                         {:port 50524
+                          :join? false
+                          :async? true}]]
+      (is server)
+      (let [resp (client/get "http://localhost:50524/")
+            name @handler-thread-name]
+        (is (= 200 (:status resp)))
+        (is (= "async-yes" (:body resp)))
+        ;; the handler must have actually executed
+        (is (some? name))
+        ;; QueuedThreadPool workers are named `qtp<id>-<n>`; selector and
+        ;; acceptor threads carry a `-selector-` / `-acceptor-` suffix, so
+        ;; matching the bare pattern proves we were dispatched to the pool
+        (is (re-matches #"qtp\d+-\d+" name)
+            (str "async handler ran on '" name "', expected a qtp worker thread"))))))
+
 (deftest jetty9-post-test
   (with-jetty [server [(test-app-maker {:request-method :post
                                         :content-type "text/plain"


### PR DESCRIPTION
Related to #170 

This patch will change our async handler behavior to align with how jetty calls async servlet. All code execution will be on worker threads instead of selectors.